### PR TITLE
RYA-443 Rya Streams Query Manager daemon program.

### DIFF
--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/entity/StreamsQuery.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/entity/StreamsQuery.java
@@ -85,4 +85,19 @@ public class StreamsQuery {
         }
         return false;
     }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("ID: ");
+        sb.append(getQueryId().toString() + "\n");
+        sb.append("Query: ");
+        sb.append(getSparql() + "\n");
+        sb.append("Is ");
+        if (!isActive) {
+            sb.append("Not ");
+        }
+        sb.append("Running.\n");
+        return sb.toString();
+    }
 }

--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/InMemoryQueryRepository.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/InMemoryQueryRepository.java
@@ -20,7 +20,9 @@ package org.apache.rya.streams.api.queries;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -32,6 +34,8 @@ import org.apache.rya.streams.api.entity.StreamsQuery;
 import org.apache.rya.streams.api.queries.QueryChangeLog.QueryChangeLogException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -46,10 +50,10 @@ import info.aduna.iteration.CloseableIteration;
  * Thread safe.
  */
 @DefaultAnnotation(NonNull.class)
-public class InMemoryQueryRepository implements QueryRepository {
-    private static final Logger LOG = LoggerFactory.getLogger(InMemoryQueryRepository.class);
+public class InMemoryQueryRepository extends AbstractScheduledService implements QueryRepository {
+    private static final Logger log = LoggerFactory.getLogger(InMemoryQueryRepository.class);
 
-    private final ReentrantLock lock = new ReentrantLock();
+    private final ReentrantLock lock = new ReentrantLock(true);
 
     /**
      * The change log that is the ground truth for describing what the queries look like.
@@ -67,20 +71,34 @@ public class InMemoryQueryRepository implements QueryRepository {
     private final Map<UUID, StreamsQuery> queriesCache = new HashMap<>();
 
     /**
+     * The listeners to be notified when new QueryChangeLogs come in.
+     */
+    private final List<QueryChangeLogListener> listeners = new ArrayList<>();
+
+    /**
+     * The {@link Scheduler} the repository uses to periodically poll for query updates.
+     */
+    private final Scheduler scheduler;
+
+    /**
      * Constructs an instance of {@link InMemoryQueryRepository}.
      *
      * @param changeLog - The change log that this repository will maintain and be based on. (not null)
+     * @param scheduler - The {@link Scheduler} this service uses to periodically check for query updates. (not null)
      */
-    public InMemoryQueryRepository(final QueryChangeLog changeLog) {
+    public InMemoryQueryRepository(final QueryChangeLog changeLog, final Scheduler scheduler) {
         this.changeLog = requireNonNull(changeLog);
+        this.scheduler = requireNonNull(scheduler);
     }
 
     @Override
-    public StreamsQuery add(final String query, final boolean isActive) throws QueryRepositoryException {
+    public StreamsQuery add(final String query, final boolean isActive)
+            throws QueryRepositoryException, IllegalStateException {
         requireNonNull(query);
 
         lock.lock();
         try {
+            checkState();
             // First record the change to the log.
             final UUID queryId = UUID.randomUUID();
             final QueryChange change = QueryChange.create(queryId, query, isActive);
@@ -100,11 +118,12 @@ public class InMemoryQueryRepository implements QueryRepository {
     }
 
     @Override
-    public Optional<StreamsQuery> get(final UUID queryId) throws QueryRepositoryException {
+    public Optional<StreamsQuery> get(final UUID queryId) throws QueryRepositoryException, IllegalStateException {
         requireNonNull(queryId);
 
         lock.lock();
         try {
+            checkState();
             // Update the cache to represent what is currently in the log.
             updateCache();
 
@@ -115,11 +134,13 @@ public class InMemoryQueryRepository implements QueryRepository {
     }
 
     @Override
-    public void updateIsActive(final UUID queryId, final boolean isActive) throws QueryRepositoryException {
+    public void updateIsActive(final UUID queryId, final boolean isActive)
+            throws QueryRepositoryException, IllegalStateException {
         requireNonNull(queryId);
 
         lock.lock();
         try {
+            checkState();
             // Update the cache to represent what is currently in the log.
             updateCache();
 
@@ -140,11 +161,12 @@ public class InMemoryQueryRepository implements QueryRepository {
     }
 
     @Override
-    public void delete(final UUID queryId) throws QueryRepositoryException {
+    public void delete(final UUID queryId) throws QueryRepositoryException, IllegalStateException {
         requireNonNull(queryId);
 
         lock.lock();
         try {
+            checkState();
             // First record the change to the log.
             final QueryChange change = QueryChange.delete(queryId);
             changeLog.write(change);
@@ -157,16 +179,17 @@ public class InMemoryQueryRepository implements QueryRepository {
     }
 
     @Override
-    public Set<StreamsQuery> list() throws QueryRepositoryException {
+    public Set<StreamsQuery> list() throws QueryRepositoryException, IllegalStateException {
         lock.lock();
         try {
+            checkState();
             // Update the cache to represent what is currently in the log.
             updateCache();
 
             // Our internal cache is already up to date, so just return its values.
             return queriesCache.values()
-                        .stream()
-                        .collect(Collectors.toSet());
+                    .stream()
+                    .collect(Collectors.toSet());
 
         } finally {
             lock.unlock();
@@ -174,7 +197,7 @@ public class InMemoryQueryRepository implements QueryRepository {
     }
 
     @Override
-    public void close() throws Exception {
+    protected void shutDown() throws Exception {
         lock.lock();
         try {
             changeLog.close();
@@ -187,11 +210,12 @@ public class InMemoryQueryRepository implements QueryRepository {
      * Updates the {@link #queriesCache} to reflect the latest position within the {@link #changeLog}.
      */
     private void updateCache() {
-        requireNonNull(changeLog);
+        log.trace("updateCache() - Enter");
 
         CloseableIteration<ChangeLogEntry<QueryChange>, QueryChangeLogException> it = null;
         try {
             // Iterate over everything since the last position that was handled within the change log.
+            log.debug("Starting cache position:" + cachePosition);
             if(cachePosition.isPresent()) {
                 it = changeLog.readFromPosition(cachePosition.get() + 1);
             } else {
@@ -203,6 +227,8 @@ public class InMemoryQueryRepository implements QueryRepository {
                 final ChangeLogEntry<QueryChange> entry = it.next();
                 final QueryChange change = entry.getEntry();
                 final UUID queryId = change.getQueryId();
+
+                log.debug("Updating the cache to reflect:\n" + change);
 
                 switch(change.getChangeType()) {
                     case CREATE:
@@ -229,12 +255,17 @@ public class InMemoryQueryRepository implements QueryRepository {
                         break;
                 }
 
+                log.debug("Notifying listeners with the updated state.");
+                final Optional<StreamsQuery> newQueryState = Optional.ofNullable(queriesCache.get(queryId));
+                listeners.forEach(listener -> listener.notify(entry, newQueryState));
+
                 cachePosition = Optional.of( entry.getPosition() );
+                log.debug("New chache position: " + cachePosition);
             }
 
         } catch (final QueryChangeLogException e) {
             // Rethrow the exception because the object the supplier tried to create could not be created.
-            throw new RuntimeException("Could not initialize the " + InMemoryQueryRepository.class.getName(), e);
+            throw new RuntimeException("Could not update the cache of " + InMemoryQueryRepository.class.getName(), e);
 
         } finally {
             // Try to close the iteration if it was opened.
@@ -243,8 +274,68 @@ public class InMemoryQueryRepository implements QueryRepository {
                     it.close();
                 }
             } catch (final QueryChangeLogException e) {
-                LOG.error("Could not close the " + CloseableIteration.class.getName(), e);
+                log.error("Could not close the " + CloseableIteration.class.getName(), e);
             }
+
+            log.trace("updateCache() - Exit");
+        }
+    }
+
+    @Override
+    protected void runOneIteration() throws Exception {
+        log.trace("runOneIteration() - Enter");
+        lock.lock();
+        try {
+            updateCache();
+        } finally {
+            lock.unlock();
+            log.trace("runOneIteration() - Exit");
+        }
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+        return scheduler;
+    }
+
+    @Override
+    public Set<StreamsQuery> subscribe(final QueryChangeLogListener listener) {
+        log.trace("subscribe(listener) - Enter");
+
+        //locks to prevent the current state from changing while subscribing.
+        lock.lock();
+        log.trace("subscribe(listener) - Acquired lock");
+        try {
+            listeners.add(listener);
+            log.trace("subscribe(listener) - Listener Registered");
+
+            //return the current state of the query repository
+            final Set<StreamsQuery> queries = queriesCache.values()
+                    .stream()
+                    .collect(Collectors.toSet());
+            log.trace("subscribe(listener) - Returning " + queries.size() + " existing queries");
+            return queries;
+        } finally {
+            log.trace("subscribe(listener) - Releasing lock");
+            lock.unlock();
+            log.trace("subscribe(listener) - Exit");
+        }
+    }
+
+    @Override
+    public void unsubscribe(final QueryChangeLogListener listener) {
+        lock.lock();
+        try {
+            listeners.remove(listener);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void checkState() {
+        if (!super.isRunning() && !listeners.isEmpty()) {
+            throw new IllegalStateException(
+                    "The Query Repository is subscribed to, but the service has not been started.");
         }
     }
 }

--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/QueryChange.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/QueryChange.java
@@ -110,6 +110,16 @@ public final class QueryChange implements Serializable {
         return false;
     }
 
+    @Override
+    public String toString() {
+        return "QueryChange: {" +
+               "    Query ID: " + queryId + ",\n" +
+               "    Change Type: " + changeType + ",\n" +
+               "    Is Active: " + isActive + ",\n" +
+               "    SPARQL: " + sparql + "\n" +
+               "}";
+    }
+
     /**
      * Create a {@link QueryChange} that represents a new SPARQL query that will be managed by Rya Streams.
      *

--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/QueryChangeLogListener.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/QueryChangeLogListener.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.api.queries;
+
+import java.util.Optional;
+
+import org.apache.rya.streams.api.entity.StreamsQuery;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Listener to be notified when {@link QueryChange}s occur on a {@link QueryChangeLog}.
+ */
+@DefaultAnnotation(NonNull.class)
+public interface QueryChangeLogListener {
+    /**
+     * Notifies the listener that a query change event has occurred in the change log.
+     * <p>
+     * <b>Note:</b>
+     * <p>
+     * The QueryRepository blocks when notifying this listener.  Long lasting operations
+     * should not be performed within this function.  Doing so will block all operations
+     * on the repository.
+     *
+     * @param queryChangeEvent - The event that occurred. (not null)
+     * @param newQueryState - The new state of the query after the query change event, this will be
+     *     absent if the change type is DELETE. (not null)
+     */
+    public void notify(final ChangeLogEntry<QueryChange> queryChangeEvent, final Optional<StreamsQuery> newQueryState);
+}

--- a/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/QueryRepository.java
+++ b/extras/rya.streams/api/src/main/java/org/apache/rya/streams/api/queries/QueryRepository.java
@@ -25,14 +25,20 @@ import java.util.UUID;
 import org.apache.rya.streams.api.entity.StreamsQuery;
 import org.apache.rya.streams.api.exception.RyaStreamsException;
 
+import com.google.common.util.concurrent.Service;
+
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Repository for adding, deleting, and listing active queries in Rya Streams.
+ *
+ * This service only needs to be started if it is being subscribed to. An
+ * {@link IllegalStateException} will be thrown if the service is subscribed to
+ * and used without being started.
  */
 @DefaultAnnotation(NonNull.class)
-public interface QueryRepository extends AutoCloseable {
+public interface QueryRepository extends Service {
 
     /**
      * Adds a new query to Rya Streams.
@@ -42,8 +48,9 @@ public interface QueryRepository extends AutoCloseable {
      *   otherwise {@code false}.
      * @return The {@link StreamsQuery} used in Rya Streams.
      * @throws QueryRepositoryException Could not add the query.
+     * @throws IllegalStateException The Service has not been started, but has been subscribed to.
      */
-    public StreamsQuery add(final String query, boolean isActive) throws QueryRepositoryException;
+    public StreamsQuery add(final String query, boolean isActive) throws QueryRepositoryException, IllegalStateException;
 
     /**
      * Updates the isActive state of a {@link StreamsQuery}. Setting this value to {@code true}
@@ -53,8 +60,9 @@ public interface QueryRepository extends AutoCloseable {
      * @param queryId - Identifies which query will be updated. (not null)
      * @param isActive - The new isActive state for the query.
      * @throws QueryRepositoryException If the query does not exist or something else caused the change to fail.
+     * @throws IllegalStateException The Service has not been started, but has been subscribed to.
      */
-    public void updateIsActive(UUID queryId, boolean isActive) throws QueryRepositoryException;
+    public void updateIsActive(UUID queryId, boolean isActive) throws QueryRepositoryException, IllegalStateException;
 
     /**
      * Get an existing query from Rya Streams.
@@ -62,24 +70,42 @@ public interface QueryRepository extends AutoCloseable {
      * @param queryId - Identifies which query will be fetched.
      * @return the {@link StreamsQuery} for the id if one exists; otherwise empty.
      * @throws QueryRepositoryException The query could not be fetched.
+     * @throws IllegalStateException The Service has not been started, but has been subscribed to.
      */
-    public Optional<StreamsQuery> get(UUID queryId) throws QueryRepositoryException;
+    public Optional<StreamsQuery> get(UUID queryId) throws QueryRepositoryException, IllegalStateException;
 
     /**
      * Removes an existing query from Rya Streams.
      *
      * @param queryID - The {@link UUID} of the query to remove. (not null)
      * @throws QueryRepositoryException Could not delete the query.
+     * @throws IllegalStateException The Service has not been started, but has been subscribed to.
      */
-    public void delete(UUID queryID) throws QueryRepositoryException;
+    public void delete(UUID queryID) throws QueryRepositoryException, IllegalStateException;
 
     /**
      * Lists all existing queries in Rya Streams.
      *
      * @return - A List of the current {@link StreamsQuery}s
      * @throws QueryRepositoryException The {@link StreamsQuery}s could not be listed.
+     * @throws IllegalStateException The Service has not been started, but has been subscribed to.
      */
-    public Set<StreamsQuery> list() throws QueryRepositoryException;
+    public Set<StreamsQuery> list() throws QueryRepositoryException, IllegalStateException;
+
+    /**
+     * Subscribes a {@link QueryChangeLogListener} to the {@link QueryRepository}.
+     *
+     * @param listener - The {@link QueryChangeLogListener} to subscribe to this {@link QueryRepository}. (not null)
+     * @return The current state of the repository in the form of {@link StreamsQuery}s.
+     */
+    public Set<StreamsQuery> subscribe(final QueryChangeLogListener listener);
+
+    /**
+     * Unsubscribe a {@link QueryChangeLogListener} from the {@link QueryRepository}.
+     *
+     * @param listener - The {@link QueryChangeLogListener} to unsubscribe from this {@link QueryRepository}. (not null)
+     */
+    public void unsubscribe(final QueryChangeLogListener listener);
 
     /**
      * A function of {@link QueryRepository} was unable to perform a function.

--- a/extras/rya.streams/api/src/test/java/org/apache/rya/streams/api/queries/InMemoryQueryRepositoryTest.java
+++ b/extras/rya.streams/api/src/test/java/org/apache/rya/streams/api/queries/InMemoryQueryRepositoryTest.java
@@ -20,6 +20,7 @@ package org.apache.rya.streams.api.queries;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,56 +28,62 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.rya.streams.api.entity.StreamsQuery;
 import org.apache.rya.streams.api.queries.QueryChangeLog.QueryChangeLogException;
 import org.junit.Test;
 
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
+
 /**
  * Unit tests the methods of {@link InMemoryQueryRepository}.
  */
 public class InMemoryQueryRepositoryTest {
+    private static final Scheduler SCHEDULE = Scheduler.newFixedRateSchedule(0L, 100, TimeUnit.MILLISECONDS);
 
     @Test
     public void canReadAddedQueries() throws Exception {
         // Setup a totally in memory QueryRepository.
-        try(final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() )) {
-            // Add some queries to it.
-            final Set<StreamsQuery> expected = new HashSet<>();
-            expected.add( queries.add("query 1", true) );
-            expected.add( queries.add("query 2", false) );
-            expected.add( queries.add("query 3", true) );
+        final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog(), SCHEDULE );
+        // Add some queries to it.
+        final Set<StreamsQuery> expected = new HashSet<>();
+        expected.add( queries.add("query 1", true) );
+        expected.add( queries.add("query 2", false) );
+        expected.add( queries.add("query 3", true) );
 
-            // Show they are in the list of all queries.
-            final Set<StreamsQuery> stored = queries.list();
-            assertEquals(expected, stored);
-        }
+        // Show they are in the list of all queries.
+        final Set<StreamsQuery> stored = queries.list();
+        assertEquals(expected, stored);
     }
 
     @Test
     public void deletedQueriesDisappear() throws Exception {
         // Setup a totally in memory QueryRepository.
-        try(final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() )) {
-            // Add some queries to it. The second one we will delete.
-            final Set<StreamsQuery> expected = new HashSet<>();
-            expected.add( queries.add("query 1", true) );
-            final UUID deletedMeId = queries.add("query 2", false).getQueryId();
-            expected.add( queries.add("query 3", true) );
+        final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog(), SCHEDULE );
+        // Add some queries to it. The second one we will delete.
+        final Set<StreamsQuery> expected = new HashSet<>();
+        expected.add( queries.add("query 1", true) );
+        final UUID deletedMeId = queries.add("query 2", false).getQueryId();
+        expected.add( queries.add("query 3", true) );
 
-            // Delete the second query.
-            queries.delete( deletedMeId );
+        // Delete the second query.
+        queries.delete( deletedMeId );
 
-            // Show only queries 1 and 3 are in the list.
-            final Set<StreamsQuery> stored = queries.list();
-            assertEquals(expected, stored);
-        }
+        // Show only queries 1 and 3 are in the list.
+        final Set<StreamsQuery> stored = queries.list();
+        assertEquals(expected, stored);
     }
 
     @Test
     public void initializedWithPopulatedChangeLog() throws Exception {
         // Setup a totally in memory QueryRepository. Hold onto the change log so that we can use it again later.
         final QueryChangeLog changeLog = new InMemoryQueryChangeLog();
-        try(final QueryRepository queries = new InMemoryQueryRepository( changeLog )) {
+        final QueryRepository queries = new InMemoryQueryRepository( changeLog, SCHEDULE );
+        try {
+            queries.startAndWait();
             // Add some queries and deletes to it.
             final Set<StreamsQuery> expected = new HashSet<>();
             expected.add( queries.add("query 1", true) );
@@ -85,11 +92,12 @@ public class InMemoryQueryRepositoryTest {
             queries.delete( deletedMeId );
 
             // Create a new totally in memory QueryRepository.
-            try(final QueryRepository initializedQueries = new InMemoryQueryRepository( changeLog )) {
-                // Listing the queries should work using an initialized change log.
-                final Set<StreamsQuery> stored = initializedQueries.list();
-                assertEquals(expected, stored);
-            }
+            final QueryRepository initializedQueries = new InMemoryQueryRepository( changeLog, SCHEDULE );
+            // Listing the queries should work using an initialized change log.
+            final Set<StreamsQuery> stored = initializedQueries.list();
+            assertEquals(expected, stored);
+        } finally {
+            queries.stop();
         }
     }
 
@@ -100,50 +108,131 @@ public class InMemoryQueryRepositoryTest {
         when(changeLog.readFromStart()).thenThrow(new QueryChangeLogException("Mocked exception."));
 
         // Create the QueryRepository and invoke one of the methods.
-        try(final QueryRepository queries = new InMemoryQueryRepository( changeLog )) {
-            queries.list();
-        }
+        final QueryRepository queries = new InMemoryQueryRepository( changeLog, SCHEDULE );
+        queries.list();
     }
 
     @Test
     public void get_present() throws Exception {
         // Setup a totally in memory QueryRepository.
-        try(final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() )) {
-            // Add a query to it.
-            final StreamsQuery query = queries.add("query 1", true);
+        final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog(), SCHEDULE );
+        // Add a query to it.
+        final StreamsQuery query = queries.add("query 1", true);
 
-            // Show the fetched query matches the expected ones.
-            final Optional<StreamsQuery> fetched = queries.get(query.getQueryId());
-            assertEquals(query, fetched.get());
-        }
+        // Show the fetched query matches the expected ones.
+        final Optional<StreamsQuery> fetched = queries.get(query.getQueryId());
+        assertEquals(query, fetched.get());
     }
 
     @Test
     public void get_notPresent() throws Exception {
         // Setup a totally in memory QueryRepository.
-        try(final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() )) {
-            // Fetch a query that was never added to the repository.
-            final Optional<StreamsQuery> query = queries.get(UUID.randomUUID());
+        final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog(), SCHEDULE );
+        // Fetch a query that was never added to the repository.
+        final Optional<StreamsQuery> query = queries.get(UUID.randomUUID());
 
-            // Show it could not be found.
-            assertFalse(query.isPresent());
-        }
+        // Show it could not be found.
+        assertFalse(query.isPresent());
     }
 
     @Test
     public void update() throws Exception {
         // Setup a totally in memory QueryRepository.
-        try(final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() )) {
+        final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog(), SCHEDULE );
+        // Add a query to it.
+        final StreamsQuery query = queries.add("query 1", true);
+
+        // Change the isActive state of that query.
+        queries.updateIsActive(query.getQueryId(), false);
+
+        // Show the fetched query matches the expected one.
+        final Optional<StreamsQuery> fetched = queries.get(query.getQueryId());
+        final StreamsQuery expected = new StreamsQuery(query.getQueryId(), query.getSparql(), false);
+        assertEquals(expected, fetched.get());
+    }
+
+    @Test
+    public void updateListenerNotify() throws Exception {
+        // Setup a totally in memory QueryRepository.
+        final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog(), SCHEDULE );
+        try {
+            queries.startAndWait();
+
             // Add a query to it.
             final StreamsQuery query = queries.add("query 1", true);
 
-            // Change the isActive state of that query.
-            queries.updateIsActive(query.getQueryId(), false);
+            final Set<StreamsQuery> existing = queries.subscribe((queryChangeEvent, newQueryState) -> {
+                final ChangeLogEntry<QueryChange> expected = new ChangeLogEntry<>(1L,
+                        QueryChange.create(queryChangeEvent.getEntry().getQueryId(), "query 2", true));
+                final Optional<StreamsQuery> expectedQueryState = Optional.of(
+                        new StreamsQuery(queryChangeEvent.getEntry().getQueryId(), "query 2", true));
 
-            // Show the fetched query matches the expected one.
-            final Optional<StreamsQuery> fetched = queries.get(query.getQueryId());
-            final StreamsQuery expected = new StreamsQuery(query.getQueryId(), query.getSparql(), false);
-            assertEquals(expected, fetched.get());
+                assertEquals(expected, queryChangeEvent);
+                assertEquals(expectedQueryState, newQueryState);
+            });
+
+            assertEquals(Sets.newHashSet(query), existing);
+
+            queries.add("query 2", true);
+        } finally {
+            queries.stop();
         }
+    }
+
+    @Test
+    public void updateListenerNotify_multiClient() throws Exception {
+        // Setup a totally in memory QueryRepository.
+        final QueryChangeLog changeLog = new InMemoryQueryChangeLog();
+        final QueryRepository queries = new InMemoryQueryRepository( changeLog, SCHEDULE );
+        final QueryRepository queries2 = new InMemoryQueryRepository( changeLog, SCHEDULE );
+
+        try {
+            queries.startAndWait();
+            queries2.startAndWait();
+
+            //show listener on repo that query was added to is being notified of the new query.
+            final CountDownLatch repo1Latch = new CountDownLatch(1);
+            queries.subscribe((queryChangeEvent, newQueryState) -> {
+                final ChangeLogEntry<QueryChange> expected = new ChangeLogEntry<>(0L,
+                        QueryChange.create(queryChangeEvent.getEntry().getQueryId(), "query 2", true));
+                final Optional<StreamsQuery> expectedQueryState = Optional.of(
+                        new StreamsQuery(queryChangeEvent.getEntry().getQueryId(), "query 2", true));
+
+                assertEquals(expected, queryChangeEvent);
+                assertEquals(expectedQueryState, newQueryState);
+                repo1Latch.countDown();
+            });
+
+            //show listener not on the repo that query was added to is being notified as well.
+            final CountDownLatch repo2Latch = new CountDownLatch(1);
+            queries2.subscribe((queryChangeEvent, newQueryState) -> {
+                final ChangeLogEntry<QueryChange> expected = new ChangeLogEntry<>(0L,
+                        QueryChange.create(queryChangeEvent.getEntry().getQueryId(), "query 2", true));
+                final Optional<StreamsQuery> expectedQueryState = Optional.of(
+                        new StreamsQuery(queryChangeEvent.getEntry().getQueryId(), "query 2", true));
+
+                assertEquals(expected, queryChangeEvent);
+                assertEquals(expectedQueryState, newQueryState);
+                repo2Latch.countDown();
+            });
+
+            queries.add("query 2", true);
+
+            assertTrue(repo1Latch.await(5, TimeUnit.SECONDS));
+            assertTrue(repo2Latch.await(5, TimeUnit.SECONDS));
+        } catch(final InterruptedException e ) {
+        } finally {
+            queries.stop();
+            queries2.stop();
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void subscribe_notStarted() throws Exception {
+        // Setup a totally in memory QueryRepository.
+        final QueryRepository queries = new InMemoryQueryRepository(new InMemoryQueryChangeLog(), SCHEDULE);
+        queries.subscribe((queryChangeEvent, newQueryState) -> {});
+
+        queries.add("query 2", true);
     }
 }

--- a/extras/rya.streams/client/src/main/java/org/apache/rya/streams/client/command/AddQueryCommand.java
+++ b/extras/rya.streams/client/src/main/java/org/apache/rya/streams/client/command/AddQueryCommand.java
@@ -20,6 +20,8 @@ package org.apache.rya.streams.client.command;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.rya.streams.api.entity.StreamsQuery;
 import org.apache.rya.streams.api.exception.RyaStreamsException;
 import org.apache.rya.streams.api.interactor.AddQuery;
@@ -35,6 +37,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -115,8 +118,11 @@ public class AddQueryCommand implements RyaStreamsCommand {
         final String topic = KafkaTopics.queryChangeLogTopic(params.ryaInstance);
         final QueryChangeLog queryChangeLog = KafkaQueryChangeLogFactory.make(bootstrapServers, topic);
 
+        //The AddQuery command doesn't use the scheduled service feature.
+        final Scheduler scheduler = Scheduler.newFixedRateSchedule(0L, 5, TimeUnit.SECONDS);
+        final QueryRepository queryRepo = new InMemoryQueryRepository(queryChangeLog, scheduler);
         // Execute the add query command.
-        try(QueryRepository queryRepo = new InMemoryQueryRepository(queryChangeLog)) {
+        try {
             final AddQuery addQuery = new DefaultAddQuery(queryRepo);
             try {
                 final StreamsQuery query = addQuery.addQuery(params.query, Boolean.parseBoolean(params.isActive));

--- a/extras/rya.streams/client/src/main/java/org/apache/rya/streams/client/command/RunQueryCommand.java
+++ b/extras/rya.streams/client/src/main/java/org/apache/rya/streams/client/command/RunQueryCommand.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.rya.streams.api.entity.StreamsQuery;
 import org.apache.rya.streams.api.queries.InMemoryQueryRepository;
@@ -39,6 +40,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -117,8 +119,11 @@ public class RunQueryCommand implements RyaStreamsCommand {
         final String topic = KafkaTopics.queryChangeLogTopic(params.ryaInstance);
         final QueryChangeLog queryChangeLog = KafkaQueryChangeLogFactory.make(bootstrapServers, topic);
 
+        //The RunQuery command doesn't use the scheduled service feature.
+        final Scheduler scheduler = Scheduler.newFixedRateSchedule(0L, 5, TimeUnit.SECONDS);
+        final QueryRepository queryRepo = new InMemoryQueryRepository(queryChangeLog, scheduler);
         // Look up the query to be executed from the change log.
-        try(QueryRepository queryRepo = new InMemoryQueryRepository(queryChangeLog)) {
+        try {
             try {
                 final UUID queryId = UUID.fromString( params.queryId );
                 final Optional<StreamsQuery> query = queryRepo.get(queryId);
@@ -131,7 +136,7 @@ public class RunQueryCommand implements RyaStreamsCommand {
                 final Set<String> topics = new HashSet<>();
                 topics.add( KafkaTopics.statementsTopic(params.ryaInstance) );
                 topics.add( KafkaTopics.queryResultsTopic(queryId) );
-                KafkaTopics.createTopic(params.zookeeperServers, topics, 1, 1);
+                KafkaTopics.createTopics(params.zookeeperServers, topics, 1, 1);
 
                 // Run the query that uses those topics.
                 final KafkaRunQuery runQuery = new KafkaRunQuery(
@@ -145,7 +150,7 @@ public class RunQueryCommand implements RyaStreamsCommand {
             } catch(final Exception e) {
                 throw new ExecutionException("Could not execute the Run Query command.", e);
             }
-        } catch(final ArgumentsException | ExecutionException e) {
+        } catch(final ExecutionException e) {
             // Rethrow the exceptions that are advertised by execute.
             throw e;
         } catch (final Exception e) {

--- a/extras/rya.streams/client/src/main/java/org/apache/rya/streams/client/command/StreamResultsCommand.java
+++ b/extras/rya.streams/client/src/main/java/org/apache/rya/streams/client/command/StreamResultsCommand.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.rya.streams.api.entity.QueryResultStream;
@@ -45,6 +46,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -132,9 +134,12 @@ public class StreamResultsCommand implements RyaStreamsCommand {
             throw new ArgumentsException("Invalid Query ID " + params.queryId);
         }
 
+        //The DeleteQuery command doesn't use the scheduled service feature.
+        final Scheduler scheduler = Scheduler.newFixedRateSchedule(0L, 5, TimeUnit.SECONDS);
+        final QueryRepository queryRepo = new InMemoryQueryRepository(queryChangeLog, scheduler);
         // Fetch the SPARQL of the query whose results will be streamed.
         final String sparql;
-        try(QueryRepository queryRepo = new InMemoryQueryRepository(queryChangeLog)) {
+        try {
             final Optional<StreamsQuery> sQuery = queryRepo.get(queryId);
             if(!sQuery.isPresent()) {
                 throw new ExecutionException("Could not read the results for query with ID " + queryId +

--- a/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/AddQueryCommandIT.java
+++ b/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/AddQueryCommandIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
@@ -38,10 +39,11 @@ import org.apache.rya.streams.kafka.serialization.queries.QueryChangeDeserialize
 import org.apache.rya.streams.kafka.serialization.queries.QueryChangeSerializer;
 import org.apache.rya.test.kafka.KafkaTestInstanceRule;
 import org.apache.rya.test.kafka.KafkaTestUtil;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
 
 /**
  * integration Test for adding a new query through a command.
@@ -64,12 +66,7 @@ public class AddQueryCommandIT {
         final Producer<?, QueryChange> queryProducer = KafkaTestUtil.makeProducer(kafka, StringSerializer.class, QueryChangeSerializer.class);
         final Consumer<?, QueryChange>queryConsumer = KafkaTestUtil.fromStartConsumer(kafka, StringDeserializer.class, QueryChangeDeserializer.class);
         final QueryChangeLog changeLog = new KafkaQueryChangeLog(queryProducer, queryConsumer, changeLogTopic);
-        queryRepo = new InMemoryQueryRepository(changeLog);
-    }
-
-    @After
-    public void cleanup() throws Exception {
-        queryRepo.close();
+        queryRepo = new InMemoryQueryRepository(changeLog, Scheduler.newFixedRateSchedule(0L, 5, TimeUnit.SECONDS));
     }
 
     @Test

--- a/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/DeleteQueryCommandIT.java
+++ b/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/DeleteQueryCommandIT.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
@@ -39,10 +40,11 @@ import org.apache.rya.streams.kafka.serialization.queries.QueryChangeDeserialize
 import org.apache.rya.streams.kafka.serialization.queries.QueryChangeSerializer;
 import org.apache.rya.test.kafka.KafkaTestInstanceRule;
 import org.apache.rya.test.kafka.KafkaTestUtil;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
 
 /**
  * Integration Test for deleting a query from Rya Streams through a command.
@@ -66,12 +68,7 @@ public class DeleteQueryCommandIT {
         final Producer<?, QueryChange> queryProducer = KafkaTestUtil.makeProducer(kafka, StringSerializer.class, QueryChangeSerializer.class);
         final Consumer<?, QueryChange>queryConsumer = KafkaTestUtil.fromStartConsumer(kafka, StringDeserializer.class, QueryChangeDeserializer.class);
         final QueryChangeLog changeLog = new KafkaQueryChangeLog(queryProducer, queryConsumer, changeLogTopic);
-        queryRepo = new InMemoryQueryRepository(changeLog);
-    }
-
-    @After
-    public void cleanup() throws Exception {
-        queryRepo.close();
+        queryRepo = new InMemoryQueryRepository(changeLog, Scheduler.newFixedRateSchedule(0L, 5, TimeUnit.SECONDS));
     }
 
     @Test

--- a/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/ListQueryCommandIT.java
+++ b/extras/rya.streams/client/src/test/java/org/apache/rya/streams/client/command/ListQueryCommandIT.java
@@ -19,6 +19,7 @@
 package org.apache.rya.streams.client.command;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
@@ -34,10 +35,11 @@ import org.apache.rya.streams.kafka.serialization.queries.QueryChangeDeserialize
 import org.apache.rya.streams.kafka.serialization.queries.QueryChangeSerializer;
 import org.apache.rya.test.kafka.KafkaTestInstanceRule;
 import org.apache.rya.test.kafka.KafkaTestUtil;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
 
 /**
  * integration Test for listing queries through a command.
@@ -60,12 +62,7 @@ public class ListQueryCommandIT {
         final Producer<?, QueryChange> queryProducer = KafkaTestUtil.makeProducer(kafka, StringSerializer.class, QueryChangeSerializer.class);
         final Consumer<?, QueryChange>queryConsumer = KafkaTestUtil.fromStartConsumer(kafka, StringDeserializer.class, QueryChangeDeserializer.class);
         final QueryChangeLog changeLog = new KafkaQueryChangeLog(queryProducer, queryConsumer, changeLogTopic);
-        queryRepo = new InMemoryQueryRepository(changeLog);
-    }
-
-    @After
-    public void cleanup() throws Exception {
-        queryRepo.close();
+        queryRepo = new InMemoryQueryRepository(changeLog, Scheduler.newFixedRateSchedule(0L, 5, TimeUnit.SECONDS));
     }
 
     @Test

--- a/extras/rya.streams/kafka/src/main/java/org/apache/rya/streams/kafka/KafkaStreamsFactory.java
+++ b/extras/rya.streams/kafka/src/main/java/org/apache/rya/streams/kafka/KafkaStreamsFactory.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.kafka;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.rya.streams.api.entity.StreamsQuery;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Builds {@link KafkaStreams} objects that are able to process a specific {@link StreamsQuery}.
+ */
+@DefaultAnnotation(NonNull.class)
+public interface KafkaStreamsFactory {
+
+    /**
+     * Builds a {@link KafkaStreams} object  that is able to process a specific {@link StreamsQuery}.
+     *
+     * @param ryaInstance - The Rya Instance the streams job is for. (not null)
+     * @param query - Defines the query that will be executed. (not null)
+     * @return A {@link KafkaStreams} object that will process the provided query.
+     * @throws KafkaStreamsFactoryException Unable to create a {@link KafkaStreams} object from the provided values.
+     */
+    public KafkaStreams make(String ryaInstance, StreamsQuery query) throws KafkaStreamsFactoryException;
+
+    /**
+     * A {@link KafkaStreamsFactory} could not create a {@link KafkaStreams} object.
+     */
+    public static class KafkaStreamsFactoryException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public KafkaStreamsFactoryException(final String message) {
+            super(message);
+        }
+
+        public KafkaStreamsFactoryException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/extras/rya.streams/kafka/src/main/java/org/apache/rya/streams/kafka/SingleThreadKafkaStreamsFactory.java
+++ b/extras/rya.streams/kafka/src/main/java/org/apache/rya/streams/kafka/SingleThreadKafkaStreamsFactory.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.kafka;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.TopologyBuilder;
+import org.apache.rya.api.function.projection.RandomUUIDFactory;
+import org.apache.rya.streams.api.entity.StreamsQuery;
+import org.apache.rya.streams.kafka.topology.TopologyBuilderFactory;
+import org.apache.rya.streams.kafka.topology.TopologyBuilderFactory.TopologyBuilderException;
+import org.apache.rya.streams.kafka.topology.TopologyFactory;
+import org.openrdf.query.MalformedQueryException;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Creates {@link KafkaStreams} objects that are able to process {@link StreamsQuery}s
+ * using a single thread of execution starting from the earliest point in within the
+ * input topic. The Application ID used by the client is based on the Query ID of the
+ * query that is being executed so that this job may resume where it left off if it
+ * is stopped.
+ */
+@DefaultAnnotation(NonNull.class)
+public class SingleThreadKafkaStreamsFactory implements KafkaStreamsFactory {
+
+    private final TopologyBuilderFactory topologyFactory = new TopologyFactory();
+
+    private final String bootstrapServersConfig;
+
+    /**
+     * Constructs an instance of {@link SingleThreadKafkaStreamsFactory}.
+     *
+     * @param bootstrapServersConfig - Configures which Kafka cluster the jobs will interact with. (not null)
+     */
+    public SingleThreadKafkaStreamsFactory(final String bootstrapServersConfig) {
+        this.bootstrapServersConfig = requireNonNull(bootstrapServersConfig);
+    }
+
+    @Override
+    public KafkaStreams make(final String ryaInstance, final StreamsQuery query) throws KafkaStreamsFactoryException {
+        requireNonNull(ryaInstance);
+        requireNonNull(query);
+
+        // Setup the Kafka Stream program.
+        final Properties streamsProps = new Properties();
+
+        // Configure the Kafka servers that will be talked to.
+        streamsProps.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServersConfig);
+
+        // Use the Query ID as the Application ID to ensure we resume where we left off the last time this command was run.
+        streamsProps.put(StreamsConfig.APPLICATION_ID_CONFIG, "RyaStreams-Query-" + query.getQueryId());
+
+        // Always start at the beginning of the input topic.
+        streamsProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        // Setup the topology that processes the Query.
+        final String statementsTopic = KafkaTopics.statementsTopic(ryaInstance);
+        final String resultsTopic = KafkaTopics.queryResultsTopic(query.getQueryId());
+
+        try {
+            final TopologyBuilder topologyBuilder = topologyFactory.build(query.getSparql(), statementsTopic, resultsTopic, new RandomUUIDFactory());
+            return new KafkaStreams(topologyBuilder, new StreamsConfig(streamsProps));
+        } catch (final MalformedQueryException | TopologyBuilderException e) {
+            throw new KafkaStreamsFactoryException("Could not create a KafkaStreams processing topology for query " + query.getQueryId(), e);
+        }
+    }
+}

--- a/extras/rya.streams/kafka/src/main/java/org/apache/rya/streams/kafka/interactor/CreateKafkaTopic.java
+++ b/extras/rya.streams/kafka/src/main/java/org/apache/rya/streams/kafka/interactor/CreateKafkaTopic.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.kafka.interactor;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+
+import org.apache.rya.streams.kafka.KafkaTopics;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Creates topics in Kafka.
+ */
+@DefaultAnnotation(NonNull.class)
+public class CreateKafkaTopic {
+
+    private final String zookeeperServers;
+
+    /**
+     * Constructs an instance of {@link CreateKafkaTopic}.
+     *
+     * @param zookeeperServers - The Zookeeper servers that are used to manage the Kafka instance. (not null)
+     */
+    public CreateKafkaTopic(final String zookeeperServers) {
+        this.zookeeperServers = requireNonNull(zookeeperServers);
+    }
+
+    /**
+     * Creates a set of Kafka topics for each topic that does not already exist.
+     *
+     * @param topicNames - The topics that will be created. (not null)
+     * @param partitions - The number of partitions that each of the topics will have.
+     * @param replicationFactor - The replication factor of the topics that are created.
+     */
+    public void createTopics(
+            final Set<String> topicNames,
+            final int partitions,
+            final int replicationFactor) {
+        KafkaTopics.createTopics(zookeeperServers, topicNames, partitions, replicationFactor);
+    }
+}

--- a/extras/rya.streams/kafka/src/test/java/org/apache/rya/streams/kafka/KafkaTopicsTest.java
+++ b/extras/rya.streams/kafka/src/test/java/org/apache/rya/streams/kafka/KafkaTopicsTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.kafka;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+/**
+ * Unit tests the methods of {@link KafkaTopics}.
+ */
+public class KafkaTopicsTest {
+
+    @Test
+    public void getRyaInstance_wellFormattedTopic() {
+        // Make a topic name using a Rya instance name.
+        final String ryaInstance = "test";
+        final String topicName = KafkaTopics.queryChangeLogTopic(ryaInstance);
+
+        // Show the rya instance name is able to be extracted from the topic.
+        final Optional<String> resolvedRyaInstance = KafkaTopics.getRyaInstance(topicName);
+        assertEquals(ryaInstance, resolvedRyaInstance.get());
+    }
+
+    @Test
+    public void getRyaInstance_invalidTopicName() {
+        // Make up an invalid topic name.
+        final String invalidTopic = "thisIsABadTopicName";
+
+        // Show there is no Rya Instance name in it.
+        final Optional<String> ryaInstance = KafkaTopics.getRyaInstance(invalidTopic);
+        assertFalse( ryaInstance.isPresent() );
+    }
+}

--- a/extras/rya.streams/kafka/src/test/java/org/apache/rya/streams/kafka/interactor/KafkaRunQueryIT.java
+++ b/extras/rya.streams/kafka/src/test/java/org/apache/rya/streams/kafka/interactor/KafkaRunQueryIT.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
@@ -52,6 +53,7 @@ import org.openrdf.model.impl.ValueFactoryImpl;
 import org.openrdf.query.impl.MapBindingSet;
 
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
 
 /**
  * Integration tests the methods of {@link KafkaRunQuery}.
@@ -83,7 +85,7 @@ public class KafkaRunQueryIT {
         final String statementsTopic = KafkaTopics.statementsTopic(ryaInstance);
 
         // This query is completely in memory, so it doesn't need to be closed.
-        final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog() );
+        final QueryRepository queries = new InMemoryQueryRepository( new InMemoryQueryChangeLog(), Scheduler.newFixedRateSchedule(0L, 5, TimeUnit.SECONDS) );
 
         // Add the query to the query repository.
         final StreamsQuery sQuery = queries.add("SELECT * WHERE { ?person <urn:worksAt> ?business . }", true);

--- a/extras/rya.streams/pom.xml
+++ b/extras/rya.streams/pom.xml
@@ -39,6 +39,7 @@
         <module>api</module>
         <module>client</module>
         <module>integration</module>
+        <module>query-manager</module>
     </modules>
     
     <profiles>

--- a/extras/rya.streams/query-manager/pom.xml
+++ b/extras/rya.streams/query-manager/pom.xml
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.apache.rya</groupId>
+        <artifactId>rya.streams.parent</artifactId>
+        <version>3.2.12-incubating-SNAPSHOT</version>
+    </parent>
+    
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>rya.streams.query-manager</artifactId>
+    
+    <name>Apache Rya Streams Query Manager</name>
+    <description>
+        This module contains the Rya Streams Query Manager.
+    </description>
+
+    <properties>
+        <rpm.staging.path>${project.build.directory}/${project.artifactId}-${project.version}-rpm-staging</rpm.staging.path>
+    </properties>
+
+    <dependencies>
+        <!-- Rya dependencies -->
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.streams.kafka</artifactId>
+        </dependency>
+
+        <!-- Apache Daemon dependencies -->
+        <dependency>
+            <groupId>commons-daemon</groupId>
+            <artifactId>commons-daemon</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+        </dependency>
+        
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.rya</groupId>
+            <artifactId>rya.test.kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <!-- Add the XSD directory as a resource so that it will be packaged in the jar. 
+           - Required so that the marshalling code is able to find the schema it is 
+           - validating XML against. -->
+        <resources>
+            <resource>
+                <directory>src/main/xsd</directory>
+            </resource>
+        </resources>
+    
+        <plugins>
+            <!-- Generate the XML marshalling java code from the XSD file defining its structure. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packageName>org.apache.rya.streams.querymanager.xml</packageName>
+                </configuration>
+            </plugin>
+         
+            <!-- Ensure the generated java source contains the license header. -->   
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>${project.basedir}/src/license/header.txt</header>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>update-generated-source-headers</id>
+                        <configuration>
+                            <basedir>${project.build.directory}/generated-sources/jaxb</basedir>
+                            <mapping>
+                                <sun-jaxb.episode>XML_STYLE</sun-jaxb.episode>
+                            </mapping>
+                        </configuration>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        
+            <!-- Create a shaded jar that is able to execute the Daemon. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                          <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.apache.rya.streams.querymanager.QueryManagerDaemon</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <!-- Use the assembly plugin to create the binary and RPM distributions. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <!-- Stage the files for the RPM construction. -->
+                    <execution>
+                        <id>stage-content-for-rpms</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <!-- This is only staging, so don't attach the built folder to the project. -->
+                            <attach>false</attach>
+                            <descriptors>
+                                <descriptor>src/assembly/rpm-staging.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>de.dentrassi.maven</groupId>
+                <artifactId>rpm</artifactId>
+                <version>0.10.0</version>
+                <executions>
+                    <execution>
+                        <id>create-rpm-properties</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>rpm</goal>
+                        </goals>
+                        <configuration>
+                            <attach>false</attach> <!-- don't attach RPM -->
+                            <group>${project.groupId}/${project.artifactId}</group> <!-- set RPM group -->
+                            <architecture>noarch</architecture>
+
+                            <signature>
+                                <skip>true</skip>
+                            </signature>
+
+                            <!-- (Un)Install scripts that enable/disable the daemon.-->
+                            <afterInstallation>
+                                <file>${rpm.staging.path}/bin/rpm/postinstall.sh</file>
+                            </afterInstallation>
+                            <beforeRemoval>
+                                <file>${rpm.staging.path}/bin/rpm/preremove.sh</file>
+                            </beforeRemoval>
+
+                             <!-- This project requires the Apache Commons Daemon applications. -->
+                            <requires>
+                                <require>jsvc</require>
+                            </requires>
+
+                            <rulesets>
+                                <ruleset>
+                                    <id>default-ruleset</id>
+                                    <rules>
+                                        <rule>
+                                            <when>
+                                                <type>directory</type>
+                                            </when>
+                                            <mode>0755</mode>
+                                        </rule>
+                                        <rule>
+                                            <when>
+                                                <type>file</type>
+                                            </when>
+                                            <mode>0644</mode>
+                                        </rule>
+                                        <file>
+                                            <when>
+                                                <suffix>configuration.xml</suffix>
+                                            </when>
+                                            <configuration>true</configuration>
+                                        </file>
+                                        <file>
+                                            <when>
+                                                <suffix>log4j.xml</suffix>
+                                            </when>
+                                            <configuration>true</configuration>
+                                        </file>
+                                        <file>
+                                            <when>
+                                                <suffix>README.txt</suffix>
+                                            </when>
+                                            <readme>true</readme>
+                                        </file>
+                                    </rules>
+                                </ruleset>
+                            </rulesets>
+                            <entries>
+                                <!-- Copy everything over to the /opt directory, except for the scripts. -->
+                                <entry>
+                                    <name>/opt/rya-streams-query-manager-${project.version}/bin/systemd</name>
+                                    <collect>
+                                        <from>${rpm.staging.path}/bin/systemd</from>
+                                        <directories>true</directories>
+                                    </collect>
+                                    <ruleset>default-ruleset</ruleset>
+                                </entry>
+                                <entry>
+                                    <name>/opt/rya-streams-query-manager-${project.version}/config</name>
+                                    <collect>
+                                        <from>${rpm.staging.path}/config</from>
+                                        <directories>true</directories>
+                                    </collect>
+                                    <ruleset>default-ruleset</ruleset>
+                                </entry>
+                                <entry>
+                                    <name>/opt/rya-streams-query-manager-${project.version}/lib</name>
+                                    <collect>
+                                        <from>${rpm.staging.path}/lib</from>
+                                        <directories>true</directories>
+                                    </collect>
+                                    <ruleset>default-ruleset</ruleset>
+                                </entry>
+                                <entry>
+                                    <name>/opt/rya-streams-query-manager-${project.version}/README.txt</name>
+                                    <collect>
+                                        <from>${rpm.staging.path}/README.txt</from>
+                                    </collect>
+                                    <ruleset>default-ruleset</ruleset>
+                                </entry>
+                                <entry>
+                                    <name>/opt/rya-streams-query-manager-${project.version}/bin/rya-streams-query-manager.sh</name>
+                                    <collect>
+                                        <from>${rpm.staging.path}/bin/rya-streams-query-manager.sh</from>
+                                    </collect>
+                                    <mode>0544</mode>
+                                </entry>
+                            </entries>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+     </build>
+</project>

--- a/extras/rya.streams/query-manager/src/assembly/component-release.xml
+++ b/extras/rya.streams/query-manager/src/assembly/component-release.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<component xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.3" 
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/component/1.1.3 http://maven.apache.org/xsd/component-1.1.3.xsd">
+
+    <!-- Define the files that will be included in the distribution. -->
+    <fileSets>
+        <!-- Configuration files. -->
+        <fileSet>
+            <directory>src/main/config</directory>
+            <outputDirectory>config</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+
+        <!-- Linux Scripts. -->
+        <fileSet>
+            <directory>src/main/scripts</directory>
+            <outputDirectory>bin</outputDirectory>
+            <lineEnding>unix</lineEnding>
+            <filtered>true</filtered>
+        </fileSet>
+
+        <!-- The README.txt file. -->
+        <fileSet>
+            <directory>src/main</directory>
+            <outputDirectory></outputDirectory>
+            <includes>
+                <include>README.txt</include>
+            </includes>
+            <lineEnding>unix</lineEnding>
+            <filtered>true</filtered>
+        </fileSet>
+
+        <!-- The shaded jar that is executed to run the program. -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>lib</outputDirectory>
+            <includes>
+                <include>${project.artifactId}-${project.version}-shaded.jar</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+
+    <!-- The commons-daemon jar file. -->
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <includes>
+                <include>commons-daemon:commons-daemon</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+</component>

--- a/extras/rya.streams/query-manager/src/assembly/rpm-staging.xml
+++ b/extras/rya.streams/query-manager/src/assembly/rpm-staging.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>rpm-staging</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <componentDescriptors>
+        <componentDescriptor>src/assembly/component-release.xml</componentDescriptor>
+    </componentDescriptors>
+</assembly>

--- a/extras/rya.streams/query-manager/src/license/header.txt
+++ b/extras/rya.streams/query-manager/src/license/header.txt
@@ -1,0 +1,16 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.

--- a/extras/rya.streams/query-manager/src/main/README.txt
+++ b/extras/rya.streams/query-manager/src/main/README.txt
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+Project: rya-streams-query-manager
+Version: ${project.version}
+
+### Description ###
+The Rya Streams Query Manager daemon service is an application that notices
+when new Rya instances are registered to use Rya Streams and then reacts to
+query create/delete/start/stop requests. Users may use the Rya Shell to issue
+those commands.
+
+This version of the manager only supports Kafka sources and it runs every query
+as a single threaded Kafka Streams job. All of the queries are processed within 
+a single JVM, so it is only suitable for a single node instance of Rya. This 
+version does not scale.
+
+### Requirements ###
+CentOS 7
+JSVC
+Java 8
+
+### Installation ###
+ 1. Copy over the RPM to the machine that will run the daemon.
+ 
+ 2. Use yum to install the RPM:
+    yum install -y ${project.artifactId}-${project.version}.noarch.rpm
+    
+ 3. Update the configuration file:
+    A. Replace "[Zookeepers used to manage Kafka. E.g.: zoo1,zoo2,zoo3]" with 
+       the zookeepers used to manage the Kafka cluster. It is a comma separated 
+       list.
+    B. Replace "[Kafka Broker Hostname]" with the IP address of the Kafka broker.
+    C. Replace the Kafka port if using something other than the default of 9092.
+    
+ 4. Start the service:
+    systemctl start rya-streams-query-manager.service
+    
+### Uninstallation ###
+ 1. Get the name of the RPM you want to uninstall:
+    rpm -qa | grep rya.streams.query-manager
+    
+ 2. Uninstall it:
+    rpm -e <the value from the last command here>

--- a/extras/rya.streams/query-manager/src/main/config/configuration.xml
+++ b/extras/rya.streams/query-manager/src/main/config/configuration.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<queryManagerConfig>
+    <!-- The Query Change Log Sources. The source defines a system where Rya
+       - Streams Query Change Logs are managed. The query manager will manage 
+       - queries for all Rya instances whose change logs are stored within the
+       - source.
+       -->
+    <queryChangeLogSource>
+        <kafka>
+            <hostname>[Kafka Broker Hostname]</hostname>
+            <port>9092</port>
+        </kafka>
+    </queryChangeLogSource>
+
+    <!-- The Query Executor. The executor defines a system for executing the
+         Rya Streams queries. -->    
+    <queryExecutor>
+        <localKafkaStreams>
+            <zookeepers>[Zookeepers used to manage Kafka. E.g.: zoo1,zoo2,zoo3]</zookeepers>
+        </localKafkaStreams>
+    </queryExecutor>
+    
+    <!-- This section defines performance related tuning values. Sensible
+       - default have been provided to simplify configuration. 
+       -->
+    <performanceTunning>
+        <!-- Indicates how frequently the Query Change Logs that are defined
+           - in the sources section of this configuration file are polled for
+           - updates. This value effects how much time may pass between the 
+           - state of a query changing and that change being represented by
+           - the execution engine.
+           -->
+        <queryChanngeLogDiscoveryPeriod>
+            <value>1</value>
+            <!-- Options: {MILLISECONDS, SECONDS, MINUTES} -->
+            <units>MINUTES</units>
+        </queryChanngeLogDiscoveryPeriod>
+    </performanceTunning>
+</queryManagerConfig>

--- a/extras/rya.streams/query-manager/src/main/config/log4j.xml
+++ b/extras/rya.streams/query-manager/src/main/config/log4j.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration debug="true"
+    xmlns:log4j='http://jakarta.apache.org/log4j/'>
+
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+        <param name="ConversionPattern"
+          value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
+        </layout>
+    </appender>
+
+    <!-- Kafka configuration configs are loud. -->
+    <logger name="org.apache.kafka.streams.StreamsConfig">
+        <level value="OFF"/>
+    </logger>
+    <logger name="org.apache.kafka.clients.consumer.ConsumerConfig">
+        <level value="OFF"/>
+    </logger>
+    <logger name="org.apache.kafka.clients.producer.ProducerConfig">
+        <level value="OFF"/>
+    </logger>
+
+    <!-- Change this level to DEBUG to see more information about what the 
+         QueryManager is doing. -->
+    <logger name="org.apache.rya.streams.querymanager.QueryManager">
+        <level value="INFO"/>
+    </logger>
+
+    <root>
+        <level value="INFO" />
+        <appender-ref ref="console" />
+    </root>
+
+</log4j:configuration>

--- a/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/QueryChangeLogSource.java
+++ b/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/QueryChangeLogSource.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager;
+
+import org.apache.rya.streams.api.queries.QueryChangeLog;
+
+import com.google.common.util.concurrent.Service;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A {@link QueryChangeLog} source represents a storage where the change logs reside, but it
+ * does not provide a way to create or remove them. Instead, subscribed {@link SourceListener}s
+ * are notified whenever a change log is created or removed from the storage.
+ */
+@DefaultAnnotation(NonNull.class)
+public interface QueryChangeLogSource extends Service {
+
+    /**
+     * Adds a {@link SourceListener} to be notified when {@link QueryChangeLog}s
+     * have been found.
+     * <p>
+     * When a new subscriber is added, it will be notified with the existing {@link QueryChangeLog}s.
+     *
+     * @param listener - The {@link SourceListener} to add. (not null)
+     */
+    public void subscribe(final SourceListener listener);
+
+    /**
+     * Removes a {@link SourceListener}.
+     *
+     * @param listener - The {@link SourceListener} to remove. (not null)
+     */
+    public void unsubscribe(final SourceListener listener);
+
+    /**
+     * A listener that is notified when a {@link QueryChangeLog} has been added or
+     * removed from a {@link QueryChangeLogSource}. The listener receives the only
+     * copy of the change log and is responsible for shutting it down.
+     */
+    @DefaultAnnotation(NonNull.class)
+    public interface SourceListener {
+        /**
+         * Notifies the subscriber that there is a new {@link QueryChangeLog} in the
+         * {@link QueryChangeLogSource}.
+         *
+         * @param ryaInstanceName - The Rya Instance name the {@link QueryChangeLog} belongs to. (not null)
+         * @param log - The new {@link QueryChangeLog}. (not null)
+         */
+        public void notifyCreate(final String ryaInstanceName, final QueryChangeLog log);
+
+        /**
+         * Notifies the subscriber that a {@link QueryChangeLog} has been deleted
+         * from the {@link QueryChangeLogSource}.
+         *
+         * @param ryaInstanceName - The rya instance whose {@link QueryChangeLog} was removed. (not null)
+         */
+        public void notifyDelete(final String ryaInstanceName);
+    }
+}

--- a/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/QueryExecutor.java
+++ b/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/QueryExecutor.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.rya.streams.api.entity.StreamsQuery;
+import org.openrdf.model.Statement;
+
+import com.google.common.util.concurrent.Service;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Represents the system that is responsible for ensuring active {@link StreamsQuery}s are
+ * being processed.
+ */
+@DefaultAnnotation(NonNull.class)
+public interface QueryExecutor extends Service {
+
+    /**
+     * Starts running a {@link StreamsQuery}.
+     *
+     * @param ryaInstanceName - The rya instance whose {@link Statement}s will be processed by the query. (not null)
+     * @param query - The query to run. (not null)
+     * @throws QueryExecutorException When the query fails to start.
+     * @throws IllegalStateException The service has not been started yet.
+     */
+    public void startQuery(final String ryaInstanceName, final StreamsQuery query) throws QueryExecutorException, IllegalStateException;
+
+    /**
+     * Stops a {@link StreamsQuery}.
+     *
+     * @param queryID - The ID of the query to stop. (not null)
+     * @throws QueryExecutorException When the query fails to stop.
+     * @throws IllegalStateException The service has not been started yet.
+     */
+    public void stopQuery(final UUID queryID) throws QueryExecutorException, IllegalStateException;
+
+    /**
+     * Stops all {@link StreamsQuery} belonging to a specific rya instance.
+     *
+     * @param ryaInstanceName - The name of the rya instance to stop all queries for. (not null)
+     * @throws QueryExecutorException When the queries fails to stop.
+     * @throws IllegalStateException The service has not been started yet.
+     */
+    public void stopAll(final String ryaInstanceName) throws QueryExecutorException, IllegalStateException;
+
+    /**
+     * @return A set of {@link UUID}s representing the current active queries.
+     * @throws QueryExecutorException Can't discover which queries are currently running.
+     * @throws IllegalStateException The service has not been started yet.
+     */
+    public Set<UUID> getRunningQueryIds() throws QueryExecutorException, IllegalStateException;
+
+    /**
+     * Exception to be used by {@link QueryExecutor} when queries fail to start or stop.
+     */
+    public class QueryExecutorException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Creates a new {@link QueryExecutorException}.
+         *
+         * @param message - The exception message.
+         * @param cause - The cause of this exception.
+         */
+        public QueryExecutorException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
+
+        /**
+         * Creates a new {@link QueryExecutorException}.
+         *
+         * @param message - The exception message.
+         */
+        public QueryExecutorException(final String message) {
+            super(message);
+        }
+
+        /**
+         * Creates a new {@link QueryExecutorException}.
+         *
+         * @param cause - The cause of this exception.
+         */
+        public QueryExecutorException(final Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/QueryManager.java
+++ b/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/QueryManager.java
@@ -1,0 +1,884 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.rya.streams.api.entity.StreamsQuery;
+import org.apache.rya.streams.api.queries.ChangeLogEntry;
+import org.apache.rya.streams.api.queries.InMemoryQueryRepository;
+import org.apache.rya.streams.api.queries.QueryChange;
+import org.apache.rya.streams.api.queries.QueryChangeLog;
+import org.apache.rya.streams.api.queries.QueryChangeLogListener;
+import org.apache.rya.streams.api.queries.QueryRepository;
+import org.apache.rya.streams.querymanager.QueryChangeLogSource.SourceListener;
+import org.apache.rya.streams.querymanager.QueryExecutor.QueryExecutorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
+import com.google.common.util.concurrent.AbstractService;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A service for managing {@link StreamsQuery} running on a Rya Streams system.
+ * <p>
+ * Only one QueryManager needs to be running to manage any number of rya
+ * instances/rya streams instances.
+ */
+@DefaultAnnotation(NonNull.class)
+public class QueryManager extends AbstractService {
+    private static final Logger log = LoggerFactory.getLogger(QueryManager.class);
+
+    /**
+     * The source of {@link QueryChangeLog}s. Each log discovered is bound to a specific
+     * Rya instnace.
+     */
+    private final QueryChangeLogSource changeLogSource;
+
+    /**
+     * The engine that is responsible for executing {@link StreamsQuery}s.
+     */
+    private final QueryExecutor queryExecutor;
+
+    /**
+     * How long blocking operations will be attempted before potentially trying again.
+     */
+    private final long blockingValue;
+
+    /**
+     * The units for {@link #blockingValue}.
+     */
+    private final TimeUnit blockingUnits;
+
+    /**
+     * Used to inform threads that the application is shutting down, so they must stop work.
+     */
+    private final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+    /**
+     * This thread pool manages the two thread used to work the {@link LogEvent}s
+     * and the {@link QueryEvent}s.
+     */
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    /**
+     * Creates a new {@link QueryManager}.
+     *
+     * @param queryExecutor - Runs the active {@link StreamsQuery}s. (not null)
+     * @param source - The {@link QueryChangeLogSource} of QueryChangeLogs. (not null)
+     * @param blockingValue - How long blocking operations will try before looping. (> 0)
+     * @param blockingUnits - The units of the {@code blockingValue}. (not null)
+     */
+    public QueryManager(
+            final QueryExecutor queryExecutor,
+            final QueryChangeLogSource source,
+            final long blockingValue,
+            final TimeUnit blockingUnits) {
+        this.changeLogSource = requireNonNull(source);
+        this.queryExecutor = requireNonNull(queryExecutor);
+        Preconditions.checkArgument(blockingValue > 0, "The blocking value must be > 0. Was: " + blockingValue);
+        this.blockingValue = blockingValue;
+        this.blockingUnits = requireNonNull(blockingUnits);
+    }
+
+    @Override
+    protected void doStart() {
+        log.info("Starting a QueryManager.");
+
+        // A work queue of discovered Query Change Logs that need to be handled.
+        // This queue exists so that the source notifying thread may be released
+        // immediately instead of calling into blocking functions.
+        final BlockingQueue<LogEvent> logEvents = new ArrayBlockingQueue<>(1024);
+
+        // A work queue of discovered Query Changes from the monitored Query Change Logs
+        // that need to be handled. This queue exists so that the Query Repository notifying
+        // thread may be released immediately instead of calling into blocking functions.
+        final BlockingQueue<QueryEvent> queryEvents = new ArrayBlockingQueue<>(1024);
+
+        try {
+            // Start up a LogEventWorker using the executor service.
+            executor.submit(new LogEventWorker(logEvents, queryEvents, blockingValue, blockingUnits, shutdownSignal));
+
+            // Start up a QueryEvent Worker using the executor service.
+            executor.submit(new QueryEventWorker(queryEvents, queryExecutor, blockingValue, blockingUnits, shutdownSignal));
+
+            // Start up the query execution framework.
+            queryExecutor.startAndWait();
+
+            // Startup the source that discovers new Query Change Logs.
+            changeLogSource.startAndWait();
+
+            // Subscribe the source a listener that writes to the LogEventWorker's work queue.
+            changeLogSource.subscribe(new LogEventWorkGenerator(logEvents, blockingValue, blockingUnits, shutdownSignal));
+        } catch(final RejectedExecutionException | UncheckedExecutionException e) {
+            log.error("Could not start up a QueryManager.", e);
+            notifyFailed(e);
+        }
+
+        // Notify the service was successfully started.
+        notifyStarted();
+
+        log.info("QueryManager has finished starting.");
+    }
+
+    @Override
+    protected void doStop() {
+        log.info("Stopping a QueryManager.");
+
+        // Set the shutdown flag so that all components that rely on that signal will stop processing.
+        shutdownSignal.set(true);
+
+        // Stop the workers and wait for them to die.
+        executor.shutdownNow();
+        try {
+            if(!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                log.warn("Waited 10 seconds for the worker threads to die, but they are still running.");
+            }
+        } catch (final InterruptedException e) {
+            log.warn("Waited 10 seconds for the worker threads to die, but they are still running.");
+        }
+
+        // Stop the source of new Change Logs.
+        try {
+            changeLogSource.stopAndWait();
+        } catch(final UncheckedExecutionException e) {
+            log.warn("Could not stop the Change Log Source.", e);
+        }
+
+        // Stop the query execution framework.
+        try {
+            queryExecutor.stopAndWait();
+        } catch(final UncheckedExecutionException e) {
+            log.warn("Could not stop the Query Executor", e);
+        }
+
+        // Notify the service was successfully stopped.
+        notifyStopped();
+
+        log.info("QueryManager has finished stopping.");
+    }
+
+    /**
+     * Offer a unit of work to a blocking queue until it is either accepted, or the
+     * shutdown signal is set.
+     *
+     * @param workQueue - The blocking work queue to write to. (not null)
+     * @param event - The event that will be offered to the work queue. (not null)
+     * @param offerValue - How long to wait when offering new work.
+     * @param offerUnits - The unit for the {@code offerValue}. (not null)
+     * @param shutdownSignal - Used to signal application shutdown has started, so
+     *   this method may terminate without ever placing the event on the queue. (not null)
+     * @return {@code true} if the evet nwas added to the queue, otherwise false.
+     */
+    private static <T> boolean offerUntilAcceptedOrShutdown(
+            final BlockingQueue<T> workQueue,
+            final T event,
+            final long offerValue,
+            final TimeUnit offerUnits,
+            final AtomicBoolean shutdownSignal) {
+        requireNonNull(workQueue);
+        requireNonNull(event);
+        requireNonNull(shutdownSignal);
+
+        boolean submitted = false;
+        while(!submitted && !shutdownSignal.get()) {
+            try {
+                submitted = workQueue.offer(event, offerValue, offerUnits);
+                if(!submitted) {
+                    log.debug("An event could not be added to a work queue after waiting 5 seconds. Trying again...");
+                }
+            } catch (final InterruptedException e) {
+                log.debug("An event could not be added to a work queue after waiting 5 seconds. Trying again...");
+            }
+        }
+        return submitted;
+    }
+
+    /**
+     * An observation that a {@link QueryChangeLog} was created within or
+     * removed from a {@link QueryChangeLogSource}.
+     */
+    @DefaultAnnotation(NonNull.class)
+    static class LogEvent {
+
+        /**
+         * The types of events that may be observed.
+         */
+        static enum LogEventType {
+            /**
+             * A {@link QueryChangeLog} was created within a {@link QueryChangeLogSource}.
+             */
+            CREATE,
+
+            /**
+             * A {@link QueryChangeLog} was deleted from a {@link QueryChangeLogSource}.
+             */
+            DELETE;
+        }
+
+        private final String ryaInstance;
+        private final LogEventType eventType;
+        private final Optional<QueryChangeLog> log;
+
+        /**
+         * Constructs an instance of {@link LogEvent}.
+         *
+         * @param ryaInstance - The Rya Instance the log is/was for. (not null)
+         * @param eventType - The type of event that was observed. (not null)
+         * @param log - The log if this is a create event. (not null)
+         */
+        private LogEvent(final String ryaInstance, final LogEventType eventType, final Optional<QueryChangeLog> log) {
+            this.ryaInstance = requireNonNull(ryaInstance);
+            this.eventType = requireNonNull(eventType);
+            this.log = requireNonNull(log);
+        }
+
+        /**
+         * @return The Rya Instance whose log was either created or deleted.
+         */
+        public String getRyaInstanceName() {
+            return ryaInstance;
+        }
+
+        /**
+         * @return The type of event that was observed.
+         */
+        public LogEventType getEventType() {
+            return eventType;
+        }
+
+        /**
+         * @return The {@link QueryChangeLog} if this is a CREATE event.
+         */
+        public Optional<QueryChangeLog> getQueryChangeLog() {
+            return log;
+        }
+
+        @Override
+        public String toString() {
+            return "LogEvent {\n" +
+                   "    Rya Instance: " + ryaInstance + ",\n" +
+                   "    Event Type: " + eventType + "\n" +
+                   "}";
+        }
+
+        /**
+         * Make a {@link LogEvent} that indicates a {@link QueryChangeLog} was created within a
+         * {@link QueryChangeLogSource}.
+         *
+         * @param ryaInstance - The Rya Instance the created log is for. (not null)
+         * @param log - The created {@link QueryChangeLog. (not null)
+         * @return A {@link LogEvent} built using the provided values.
+         */
+        public static LogEvent create(final String ryaInstance, final QueryChangeLog log) {
+            return new LogEvent(ryaInstance, LogEventType.CREATE, Optional.of(log));
+        }
+
+        /**
+         * Make a {@link LogEvent} that indicates a {@link QueryChangeLog} was deleted from
+         * a {@link QueryChangeLogSource}.
+         *
+         * @param ryaInstance - The Rya Instance whose log was deleted. (not null)
+         * @return A {@link LogEvent} built using the provided values.
+         */
+        public static LogEvent delete(final String ryaInstance) {
+            return new LogEvent(ryaInstance, LogEventType.DELETE, Optional.empty());
+        }
+    }
+
+    /**
+     * An observation that a {@link StreamsQuery} needs to be executing or not
+     * via the provided {@link QueryExecutor}.
+     */
+    @DefaultAnnotation(NonNull.class)
+    static class QueryEvent {
+
+        /**
+         * The type of events that may be observed.
+         */
+        public static enum QueryEventType {
+            /**
+             * Indicates a {@link StreamsQuery} needs to be executing.
+             */
+            EXECUTING,
+
+            /**
+             * Indicates a {@link StreamsQuery} needs to be stopped.
+             */
+            STOPPED,
+
+            /**
+             * Indicates all {@link StreamsQuery}s for a Rya instance need to be stopped.
+             */
+            STOP_ALL;
+        }
+
+        private final String ryaInstance;
+        private final QueryEventType type;
+        private final Optional<UUID> queryId;
+        private final Optional<StreamsQuery> query;
+
+        /**
+         * Constructs an instance of {@link QueryEvent}.
+         *
+         * @param ryaInstance - The Rya instance that generated the event. (not null)
+         * @param type - Indicates whether the query needs to be executing or not. (not null)
+         * @param queryId - If stopped, the ID of the query that must not be running. (not null)
+         * @param query - If executing, the StreamsQuery that defines what should be executing. (not null)
+         */
+        private QueryEvent(
+                final String ryaInstance,
+                final QueryEventType type,
+                final Optional<UUID> queryId,
+                final Optional<StreamsQuery> query) {
+            this.ryaInstance = requireNonNull(ryaInstance);
+            this.type = requireNonNull(type);
+            this.queryId = requireNonNull(queryId);
+            this.query = requireNonNull(query);
+        }
+
+        /**
+         * @return The Rya instance that generated the event.
+         */
+        public String getRyaInstance() {
+            return ryaInstance;
+        }
+
+        /**
+         * @return Indicates whether the query needs to be executing or not.
+         */
+        public QueryEventType getType() {
+            return type;
+        }
+
+        /**
+         * @return If stopped, the ID of the query that must not be running. Otherwise absent.
+         */
+        public Optional<UUID> getQueryId() {
+            return queryId;
+        }
+
+        /**
+         * @return If executing, the StreamsQuery that defines what should be executing. Otherwise absent.
+         */
+        public Optional<StreamsQuery> getStreamsQuery() {
+            return query;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(ryaInstance, type, queryId, query);
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if(o instanceof QueryEvent) {
+                final QueryEvent other = (QueryEvent) o;
+                return Objects.equals(ryaInstance, other.ryaInstance) &&
+                        Objects.equals(type, other.type) &&
+                        Objects.equals(queryId, other.queryId) &&
+                        Objects.equals(query, other.query);
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder string = new StringBuilder();
+            string.append("Query Event {\n")
+                  .append("    Rya Instance: ").append(ryaInstance).append(",\n")
+                  .append("    Type: ").append(type).append(",\n");
+            switch(type) {
+                case EXECUTING:
+                    append(string, query.get());
+                    break;
+                case STOPPED:
+                    string.append("    Query ID: ").append(queryId.get()).append("\n");
+                    break;
+                case STOP_ALL:
+                    break;
+                default:
+                    // Default to showing everything that is in the object.
+                    string.append("    Query ID: ").append(queryId.get()).append("\n");
+                    append(string, query.get());
+                    break;
+            }
+            string.append("}");
+            return string.toString();
+        }
+
+        private void append(final StringBuilder string, final StreamsQuery query) {
+            requireNonNull(string);
+            requireNonNull(query);
+            string.append("    Streams Query {\n")
+                  .append("        Query ID: ").append(query.getQueryId()).append(",\n")
+                  .append("        Is Active: ").append(query.isActive()).append(",\n")
+                  .append("        SPARQL: ").append(query.getSparql()).append("\n")
+                  .append("    }");
+        }
+
+        /**
+         * Create a {@link QueryEvent} that indicates a query needs to be executing.
+         *
+         * @param ryaInstance - The Rya instance that generated the event. (not null)
+         * @param query - The StreamsQuery that defines what should be executing. (not null)
+         * @return A {@link QueryEvent} built using the provided values.
+         */
+        public static QueryEvent executing(final String ryaInstance, final StreamsQuery query) {
+            return new QueryEvent(ryaInstance, QueryEventType.EXECUTING, Optional.empty(), Optional.of(query));
+        }
+
+        /**
+         * Create a {@link QueryEvent} that indicates a query needs to be stopped.
+         *
+         * @param ryaInstance - The Rya instance that generated the event. (not null)
+         * @param queryId - The ID of the query that must not be running. (not null)
+         * @return A {@link QueryEvent} built using the provided values.
+         */
+        public static QueryEvent stopped(final String ryaInstance, final UUID queryId) {
+            return new QueryEvent(ryaInstance, QueryEventType.STOPPED, Optional.of(queryId), Optional.empty());
+        }
+
+        /**
+         * Create a {@link QueryEvent} that indicates all queries for a Rya instance needs to be stopped.
+         *
+         * @param ryaInstance - The Rya instance that generated the event. (not null)
+         * @return A {@link QueryEvent} built using the provided values.
+         */
+        public static QueryEvent stopALL(final String ryaInstance) {
+            return new QueryEvent(ryaInstance, QueryEventType.STOP_ALL, Optional.empty(), Optional.empty());
+        }
+    }
+
+    /**
+     * Listens to a {@link QueryChangeLogSource} and adds observations to the provided
+     * work queue. It does so until the provided shutdown signal is set.
+     */
+    @DefaultAnnotation(NonNull.class)
+    static class LogEventWorkGenerator implements SourceListener {
+
+        private final BlockingQueue<LogEvent> workQueue;
+        private final AtomicBoolean shutdownSignal;
+        private final long offerValue;
+        private final TimeUnit offerUnits;
+
+        /**
+         * Constructs an instance of {@link QueryManagerSourceListener}.
+         *
+         * @param workQueue - A blocking queue that will have {@link LogEvent}s offered to it. (not null)
+         * @param offerValue - How long to wait when offering new work.
+         * @param offerUnits - The unit for the {@code offerValue}. (not null)
+         * @param shutdownSignal - Indicates to this listener that it needs to stop adding events
+         *   to the work queue because the application is shutting down. (not null)
+         */
+        public LogEventWorkGenerator(
+                final BlockingQueue<LogEvent> workQueue,
+                final long offerValue,
+                final TimeUnit offerUnits,
+                final AtomicBoolean shutdownSignal) {
+            this.workQueue = requireNonNull(workQueue);
+            this.shutdownSignal = requireNonNull(shutdownSignal);
+            this.offerValue = offerValue;
+            this.offerUnits = requireNonNull(offerUnits);
+        }
+
+        @Override
+        public void notifyCreate(final String ryaInstanceName, final QueryChangeLog changeLog) {
+            log.info("A new Query Change Log has been discovered for Rya Instance " + ryaInstanceName + ". All " +
+                    "queries that are set to active within it will be started.");
+
+            // Create an event that summarizes this notification.
+            final LogEvent event = LogEvent.create(ryaInstanceName, changeLog);
+
+            // Offer it to the worker until there is room for it in the work queue, or we are shutting down.
+            offerUntilAcceptedOrShutdown(workQueue, event, offerValue, offerUnits, shutdownSignal);
+        }
+
+        @Override
+        public void notifyDelete(final String ryaInstanceName) {
+            log.info("The Query Change Log for Rya Instance " + ryaInstanceName + " has been deleted. All of the " +
+                    "queries related to that instance will be stopped.");
+
+            // Create an event that summarizes this notification.
+            final LogEvent event = LogEvent.delete(ryaInstanceName);
+
+            // Offer it to the worker until there is room for it in the work queue, or we are shutting down.
+            offerUntilAcceptedOrShutdown(workQueue, event, offerValue, offerUnits, shutdownSignal);
+        }
+    }
+
+    /**
+     * Processes a work queue of {@link LogEvent}s.
+     * <p/>
+     * Whenever a new log has been created, then it registers a {@link QueryEventWorkGenerator}
+     * that generates {@link QueryEvent}s based on the content and updates to the discovered
+     * {@link QueryChagneLog}.
+     * <p/>
+     * Whenever a log is deleted, then the generator is stopped and a stop all {@link QueryEvent}
+     * is written to the work queue.
+     */
+    @DefaultAnnotation(NonNull.class)
+    static class LogEventWorker implements Runnable {
+
+        /**
+         * A map of Rya Instance name to he Query Repository for that instance.
+         */
+        private final Map<String, QueryRepository> repos = new HashMap<>();
+
+        private final BlockingQueue<LogEvent> logWorkQueue;
+        private final BlockingQueue<QueryEvent> queryWorkQueue;
+        private final long blockingValue;
+        private final TimeUnit blockingUnits;
+        private final AtomicBoolean shutdownSignal;
+
+        /**
+         * Constructs an instance of {@link LogEventWorker}.
+         *
+         * @param logWorkQueue - A queue of {@link LogEvent}s that will be worked by this object. (not null)
+         * @param queryWorkQueue - A queue where {@link QueryEvent}s will be placed by this object. (not null)
+         * @param blockingValue - How long to wait when polling/offering new work.
+         * @param blockingUnits - The unit for the {@code blockingValue}. (not null)
+         * @param shutdownSignal - Indicates when the application has been shutdown, so the executing thread
+         *   may exit the {@link #run()} method. (not null)
+         */
+        public LogEventWorker(
+                final BlockingQueue<LogEvent> logWorkQueue,
+                final BlockingQueue<QueryEvent> queryWorkQueue,
+                final long blockingValue,
+                final TimeUnit blockingUnits,
+                final AtomicBoolean shutdownSignal) {
+            this.logWorkQueue = requireNonNull(logWorkQueue);
+            this.queryWorkQueue = requireNonNull(queryWorkQueue);
+            this.blockingValue = blockingValue;
+            this.blockingUnits = requireNonNull(blockingUnits);
+            this.shutdownSignal = requireNonNull(shutdownSignal);
+        }
+
+        @Override
+        public void run() {
+            // Run until the shutdown signal is set.
+            while(!shutdownSignal.get()) {
+                try {
+                    // Pull a unit of work from the queue.
+                    log.debug("LogEventWorker - Polling the work queue for a new LogEvent.");
+                    final LogEvent logEvent = logWorkQueue.poll(blockingValue, blockingUnits);
+                    if(logEvent == null) {
+                        // Poll again if nothing was found.
+                        continue;
+                    }
+
+                    log.info("LogEventWorker - handling: \n" + logEvent);
+                    final String ryaInstance = logEvent.getRyaInstanceName();
+
+                    switch(logEvent.getEventType()) {
+                        case CREATE:
+                            // If we see a create message for a Rya Instance we are already maintaining,
+                            // then don't do anything.
+                            if(repos.containsKey(ryaInstance)) {
+                                log.warn("LogEventWorker - A repository is already being managed for the Rya Instance " +
+                                        ryaInstance + ". This message will be ignored.");
+                                continue;
+                            }
+
+                            // Create and start a QueryRepository for the discovered log. Hold onto the repository
+                            // so that it may be shutdown later.
+                            final Scheduler scheduler = Scheduler.newFixedRateSchedule(0, blockingValue, blockingUnits);
+                            final QueryRepository repo = new InMemoryQueryRepository(logEvent.getQueryChangeLog().get(), scheduler);
+                            repo.startAndWait();
+                            repos.put(ryaInstance, repo);
+
+                            // Subscribe a worker that adds the Query Events to the queryWorkQueue queue.
+                            // A count down latch is used to ensure the returned set of queries are handled
+                            // prior to any notifications from the repository.
+                            final CountDownLatch subscriptionWorkFinished = new CountDownLatch(1);
+                            final QueryEventWorkGenerator queryWorkGenerator =
+                                    new QueryEventWorkGenerator(ryaInstance, subscriptionWorkFinished, queryWorkQueue,
+                                            blockingValue, blockingUnits, shutdownSignal);
+
+                            log.debug("LogEventWorker - Setting up a QueryWorkGenerator...");
+                            final Set<StreamsQuery> queries = repo.subscribe(queryWorkGenerator);
+                            log.debug("LogEventWorker - Finished setting up a QueryWorkGenerator.");
+
+                            // Handle the view of the queries within the repository as it existed when
+                            // the subscription was registered.
+                            queries.stream()
+                            .forEach(query -> {
+                                // Create a QueryEvent that represents the active state of the existing query.
+                                final QueryEvent queryEvent = query.isActive() ?
+                                        QueryEvent.executing(ryaInstance, query) : QueryEvent.stopped(ryaInstance, query.getQueryId());
+                                log.debug("LogEventWorker - offering: " + queryEvent);
+
+                                // Offer it to the worker until there is room for it in the work queue, or we are shutting down.
+                                offerUntilAcceptedOrShutdown(queryWorkQueue, queryEvent, blockingValue, blockingUnits, shutdownSignal);
+                            });
+
+                            // Indicate the subscription work is finished so that the registered listener may start
+                            // adding work to the queue.
+                            log.info("LogEventWorker - Counting down the subscription work latch.");
+                            subscriptionWorkFinished.countDown();
+                            break;
+
+                        case DELETE:
+                            if(repos.containsKey(ryaInstance)) {
+                                // Shut down the query repository for the Rya instance. This ensures the listener will
+                                // not receive any more work that needs to be done.
+                                final QueryRepository deletedRepo = repos.remove(ryaInstance);
+                                deletedRepo.stopAndWait();
+
+                                // Add work that stops all of the queries related to the instance.
+                                final QueryEvent stopAllEvent = QueryEvent.stopALL(ryaInstance);
+                                offerUntilAcceptedOrShutdown(queryWorkQueue, stopAllEvent, blockingValue, blockingUnits, shutdownSignal);
+                            }
+                            break;
+                    }
+                } catch (final InterruptedException e) {
+                    log.debug("LogEventWorker did not see any new events over the past 5 seconds. Polling again...");
+                }
+            }
+
+            log.info("LogEventWorker shutting down...");
+
+            // Shutdown all of the QueryRepositories that were started.
+            repos.values().forEach(repo -> repo.stopAndWait());
+
+            log.info("LogEventWorker shut down.");
+        }
+    }
+
+    /**
+     * Listens to a {@link QueryRepository} and adds observations to the provided work queue.
+     * It does so until the provided shutdown signal is set.
+     */
+    @DefaultAnnotation(NonNull.class)
+    static class QueryEventWorkGenerator implements QueryChangeLogListener {
+
+        private final String ryaInstance;
+        private final CountDownLatch subscriptionWorkFinished;
+        private final BlockingQueue<QueryEvent> queryWorkQueue;
+        private final long blockingValue;
+        private final TimeUnit blockingUnits;
+        private final AtomicBoolean shutdownSignal;
+
+        /**
+         * Constructs an instance of {@link QueryEventWorkGenerator}.
+         *
+         * @param ryaInstance - The rya instance whose log this objects is watching. (not null)
+         * @param subscriptionWorkFinished - Indicates when work that needs to be completed before this
+         *   listener handles notifications is completed. (not null)
+         * @param queryWorkQueue - A queue where {@link QueryEvent}s will be placed by this object. (not null)
+         * @param blockingValue - How long to wait when polling/offering new work.
+         * @param blockingUnits - The unit for the {@code blockingValue}. (not null)
+         * @param shutdownSignal - Indicates to this listener that it needs to stop adding events
+         *   to the work queue because the application is shutting down. (not null)
+         */
+        public QueryEventWorkGenerator(
+                final String ryaInstance,
+                final CountDownLatch subscriptionWorkFinished,
+                final BlockingQueue<QueryEvent> queryWorkQueue,
+                final long blockingValue,
+                final TimeUnit blockingUnits,
+                final AtomicBoolean shutdownSignal) {
+            this.ryaInstance = requireNonNull(ryaInstance);
+            this.subscriptionWorkFinished = requireNonNull(subscriptionWorkFinished);
+            this.queryWorkQueue = requireNonNull(queryWorkQueue);
+            this.blockingValue = blockingValue;
+            this.blockingUnits = requireNonNull(blockingUnits);
+            this.shutdownSignal = requireNonNull(shutdownSignal);
+        }
+
+        @Override
+        public void notify(final ChangeLogEntry<QueryChange> queryChangeEvent, final Optional<StreamsQuery> newQueryState) {
+            requireNonNull(queryChangeEvent);
+            requireNonNull(newQueryState);
+
+            // Wait for the subscription work to be finished.
+            try {
+                log.debug("Waiting for Subscription Work Finished latch to release...");
+                while(!shutdownSignal.get() && !subscriptionWorkFinished.await(blockingValue, blockingUnits)) {
+                    log.debug("Still waiting...");
+                }
+                log.debug("Subscription Work Finished latch to released.");
+            } catch (final InterruptedException e) {
+                log.warn("Interrupted while waiting for the Subscription Work Finished latch to be " +
+                        "released. Shutting down?", e);
+            }
+
+            // If we left the loop because of a shutdown, return immediately.
+            if(shutdownSignal.get()) {
+                log.debug("Not processing notification. Shutting down.");
+                return;
+            }
+
+            // Generate work from the notification.
+            final QueryChange change = queryChangeEvent.getEntry();
+            switch(change.getChangeType()) {
+                case CREATE:
+                    if(newQueryState.isPresent()) {
+                        log.info("Rya Instance " + ryaInstance + " created Rya Streams query " + newQueryState + ".");
+                        final StreamsQuery newQuery = newQueryState.get();
+                        if(newQuery.isActive()) {
+                            final QueryEvent executeNewQuery = QueryEvent.executing(ryaInstance, newQuery);
+                            offerUntilAcceptedOrShutdown(queryWorkQueue, executeNewQuery, blockingValue, blockingUnits, shutdownSignal);
+                        }
+                    } else {
+                        log.error("Received a CREATE QueryChange for Rya Instance: " + ryaInstance +
+                                ", Query ID: " + change.getQueryId() + ", but the QueryRepository did not supply a " +
+                                "StreamsQuery representing the created query. The query will not be processed.");
+                    }
+                    break;
+
+                case DELETE:
+                    final UUID deletedQueryId = change.getQueryId();
+                    log.info("Rya Instance " + ryaInstance + " deleted Rya Streams query with ID " + deletedQueryId);
+                    final QueryEvent stopDeletedQuery = QueryEvent.stopped(ryaInstance, deletedQueryId);
+                    offerUntilAcceptedOrShutdown(queryWorkQueue, stopDeletedQuery, blockingValue, blockingUnits, shutdownSignal);
+                    break;
+
+                case UPDATE:
+                    if(newQueryState.isPresent()) {
+                        final StreamsQuery updatedQuery = newQueryState.get();
+                        if(updatedQuery.isActive()) {
+                            log.info("Rya Instance " + ryaInstance + " updated Rya Streams query with ID " +
+                                    updatedQuery.getQueryId() + " to be active.");
+                            final QueryEvent executeUpdatedQuery = QueryEvent.executing(ryaInstance, updatedQuery);
+                            offerUntilAcceptedOrShutdown(queryWorkQueue, executeUpdatedQuery, blockingValue, blockingUnits, shutdownSignal);
+                        } else {
+                            log.info("Rya Instance " + ryaInstance + " updated Rya Streams query with ID " +
+                                    updatedQuery.getQueryId() + " to be inactive.");
+                            final QueryEvent stopUpdatedQuery = QueryEvent.stopped(ryaInstance, updatedQuery.getQueryId());
+                            offerUntilAcceptedOrShutdown(queryWorkQueue, stopUpdatedQuery, blockingValue, blockingUnits, shutdownSignal);
+                        }
+                    } else {
+                        log.error("Received an UPDATE QueryChange for Rya Instance: " + ryaInstance +
+                                ", Query ID: " + change.getQueryId() + ", but the QueryRepository did not supply a " +
+                                "StreamsQuery representing the created query. The query will not be processed.");
+                    }
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Processes a work queue of {@link QueryEvent}s.
+     * <p/>
+     * Each type of event maps the to corresponding method on {@link QueryExecutor} that is called into.
+     */
+    @DefaultAnnotation(NonNull.class)
+    static class QueryEventWorker implements Runnable {
+
+        private final BlockingQueue<QueryEvent> workQueue;
+        private final QueryExecutor queryExecutor;
+        private final long pollingValue;
+        private final TimeUnit pollingUnits;
+        private final AtomicBoolean shutdownSignal;
+
+        /**
+         * Constructs an instance of {@link QueryEventWorker}.
+         *
+         * @param workQueue - A queue of {@link QueryEvent}s that will be worked by this object. (not null)
+         * @param queryExecutor - Responsible for executing the {@link StreamsQuery}s. (not null)
+         * @param pollingValue - How long to wait when polling for new work.
+         * @param pollingUnits - The units for the {@code pollingValue}. (not null)
+         * @param shutdownSignal - Indicates when the application has been shutdown, so the executing thread
+         *   may exit the {@link #run()} method. (not null)
+         */
+        public QueryEventWorker(
+                final BlockingQueue<QueryEvent> workQueue,
+                final QueryExecutor queryExecutor,
+                final long pollingValue,
+                final TimeUnit pollingUnits,
+                final AtomicBoolean shutdownSignal) {
+            this.workQueue = requireNonNull(workQueue);
+            this.queryExecutor = requireNonNull(queryExecutor);
+            this.pollingValue = pollingValue;
+            this.pollingUnits = requireNonNull(pollingUnits);
+            this.shutdownSignal = requireNonNull(shutdownSignal);
+        }
+
+        @Override
+        public void run() {
+            log.info("QueryEventWorker starting.");
+
+            // Run until the shutdown signal is set.
+            while(!shutdownSignal.get()) {
+                // Pull a unit of work from the queue.
+                try {
+                    log.debug("Polling the work queue for a new QueryEvent.");
+                    final QueryEvent event = workQueue.poll(pollingValue, pollingUnits);
+                    if(event == null) {
+                        // Poll again if nothing was found.
+                        continue;
+                    }
+
+                    log.info("QueryEventWorker handling:\n" + event);
+
+                    // Ensure the state within the executor matches the query event's state.
+                    switch(event.getType()) {
+                        case EXECUTING:
+                            try {
+                                queryExecutor.startQuery(event.getRyaInstance(), event.getStreamsQuery().get());
+                            } catch (final IllegalStateException | QueryExecutorException e) {
+                                log.error("Could not start a query represented by the following work: " + event, e);
+                            }
+                            break;
+
+                        case STOPPED:
+                            try {
+                                queryExecutor.stopQuery(event.getQueryId().get());
+                            } catch (final IllegalStateException | QueryExecutorException e) {
+                                log.error("Could not stop a query represented by the following work: " + event, e);
+                            }
+                            break;
+
+                        case STOP_ALL:
+                            try {
+                                queryExecutor.stopAll(event.getRyaInstance());
+                            } catch (final IllegalStateException | QueryExecutorException e) {
+                                log.error("Could not stop all queries represented by the following work: " + event, e);
+                            }
+                        break;
+                    }
+                } catch (final InterruptedException e) {
+                    log.debug("QueryEventWorker interrupted. Probably shutting down.");
+                }
+            }
+            log.info("QueryEventWorker shut down.");
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/QueryManagerDaemon.java
+++ b/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/QueryManagerDaemon.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import javax.xml.bind.JAXBException;
+
+import org.apache.commons.daemon.Daemon;
+import org.apache.commons.daemon.DaemonContext;
+import org.apache.commons.daemon.DaemonInitException;
+import org.apache.rya.streams.kafka.KafkaStreamsFactory;
+import org.apache.rya.streams.kafka.SingleThreadKafkaStreamsFactory;
+import org.apache.rya.streams.kafka.interactor.CreateKafkaTopic;
+import org.apache.rya.streams.querymanager.kafka.KafkaQueryChangeLogSource;
+import org.apache.rya.streams.querymanager.kafka.LocalQueryExecutor;
+import org.apache.rya.streams.querymanager.xml.Kafka;
+import org.apache.rya.streams.querymanager.xml.QueryManagerConfig;
+import org.apache.rya.streams.querymanager.xml.QueryManagerConfig.PerformanceTunning.QueryChanngeLogDiscoveryPeriod;
+import org.apache.rya.streams.querymanager.xml.QueryManagerConfigUnmarshaller;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * JSVC integration code for a {@link QueryManager} to be used as a non-Windows daemon.
+ */
+@DefaultAnnotation(NonNull.class)
+public class QueryManagerDaemon implements Daemon {
+
+    private static final Logger log = LoggerFactory.getLogger(QueryManagerDaemon.class);
+
+    /**
+     * The default configuration file's path for the application.
+     */
+    private static final Path DEFAULT_CONFIGURATION_PATH = Paths.get("config/configuration.xml");
+
+    /**
+     * Command line parameters that are used by all commands that interact with Kafka.
+     */
+    class DaemonParameters {
+        @Parameter(names = {"--config", "-c"}, required = false, description = "The path to the application's configuration file.")
+        public String config;
+    }
+
+    private QueryManager manager = null;
+
+    @Override
+    public void init(final DaemonContext context) throws DaemonInitException, Exception {
+        requireNonNull(context);
+
+        // Parse the command line arguments for the configuration file to use.
+        final String[] args = context.getArguments();
+        final DaemonParameters params = new DaemonParameters();
+        try {
+            new JCommander(params).parse(args);
+        } catch(final ParameterException e) {
+            throw new DaemonInitException("Unable to parse the command line arguments.", e);
+        }
+        final Path configFile = params.config != null ? Paths.get(params.config) : DEFAULT_CONFIGURATION_PATH;
+        log.info("Loading the following configuration file: " + configFile);
+
+        // Unmarshall the configuration file into an object.
+        final QueryManagerConfig config;
+        try(final InputStream stream = Files.newInputStream(configFile)) {
+            config = QueryManagerConfigUnmarshaller.unmarshall(stream);
+        } catch(final JAXBException | SAXException e) {
+            throw new DaemonInitException("Unable to marshall the configuration XML file: " + configFile, e);
+        }
+
+        // Read the source polling period from the configuration.
+        final QueryChanngeLogDiscoveryPeriod periodConfig = config.getPerformanceTunning().getQueryChanngeLogDiscoveryPeriod();
+        final long period = periodConfig.getValue().longValue();
+        final TimeUnit units = TimeUnit.valueOf( periodConfig.getUnits().toString() );
+        log.info("Query Change Log Polling Period: " + period + " " + units);
+        final Scheduler scheduler = Scheduler.newFixedRateSchedule(0, period, units);
+
+        // Initialize a QueryChangeLogSource.
+        final Kafka kafka = config.getQueryChangeLogSource().getKafka();
+        log.info("Kafka Source: " + kafka.getHostname() + ":" + kafka.getPort());
+        final QueryChangeLogSource source = new KafkaQueryChangeLogSource(kafka.getHostname(), kafka.getPort(), scheduler);
+
+        // Initialize a QueryExecutor.
+        final String zookeeperServers = config.getQueryExecutor().getLocalKafkaStreams().getZookeepers();
+        final KafkaStreamsFactory streamsFactory = new SingleThreadKafkaStreamsFactory(kafka.getHostname() + ":" + kafka.getPort());
+        final QueryExecutor queryExecutor = new LocalQueryExecutor(new CreateKafkaTopic(zookeeperServers), streamsFactory);
+
+        // Initialize the QueryManager using the configured resources.
+        manager = new QueryManager(queryExecutor, source, period, units);
+    }
+
+    @Override
+    public void start() throws Exception {
+        log.info("Starting the Rya Streams Query Manager Daemon.");
+        manager.startAndWait();
+    }
+
+    @Override
+    public void stop() throws Exception {
+        log.info("Stopping the Rya Streams Query Manager Daemon.");
+        manager.stopAndWait();
+    }
+
+    @Override
+    public void destroy() { }
+}

--- a/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/kafka/KafkaQueryChangeLogSource.java
+++ b/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/kafka/KafkaQueryChangeLogSource.java
@@ -1,0 +1,219 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager.kafka;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.rya.streams.kafka.KafkaTopics;
+import org.apache.rya.streams.kafka.queries.KafkaQueryChangeLog;
+import org.apache.rya.streams.kafka.queries.KafkaQueryChangeLogFactory;
+import org.apache.rya.streams.querymanager.QueryChangeLogSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractScheduledService;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Represents a Kafka Server that manages {@link KafkaQueryChangeLog}s.
+ * <p/>
+ * Thread safe.
+ */
+@DefaultAnnotation(NonNull.class)
+public class KafkaQueryChangeLogSource extends AbstractScheduledService implements QueryChangeLogSource {
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaQueryChangeLogSource.class);
+
+    /**
+     * Ensures thread safe interactions with this object.
+     */
+    private final ReentrantLock lock = new ReentrantLock();
+
+    /**
+     * Used by the service to configure how often it polls the Kafka Server for topics.
+     */
+    private final Scheduler scheduler;
+
+    /**
+     * Which Kafka Server this source represents.
+     */
+    private final String kafkaBootstrapServer;
+
+    /**
+     * Listeners that need to be notified when logs are created/deleted.
+     */
+    private final Set<SourceListener> listeners = new HashSet<>();
+
+    /**
+     * Maps Rya instance names to the Query Change Log topic name in Kafka. This map is used to
+     * keep track of how the change logs change over time within the Kafka Server.
+     */
+    private final HashMap<String, String> knownChangeLogs = new HashMap<>();
+
+    /**
+     * A consumer that is used to poll the Kafka Server for topics.
+     */
+    private KafkaConsumer<String, String> listTopicsConsumer;
+
+    /**
+     * Constructs an instance of {@link KafkaQueryChangeLogSource}.
+     *
+     * @param kafkaHostname - The hostname of the Kafka Server that is the source. (not null)
+     * @param kafkaPort - The port of the Kafka Server that is the source. (not null)
+     * @param scheduler - How frequently this source will poll the Kafka Server for topics. (not null)
+     */
+    public KafkaQueryChangeLogSource(
+            final String kafkaHostname,
+            final int kafkaPort,
+            final Scheduler scheduler) {
+        kafkaBootstrapServer = requireNonNull(kafkaHostname) + ":" + kafkaPort;
+        this.scheduler = requireNonNull(scheduler);
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        log.info("Kafka Query Change Log Source watching " + kafkaBootstrapServer + " starting up...");
+
+        // Setup the consumer that is used to list topics for the source.
+        final Properties consumerProperties = new Properties();
+        consumerProperties.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrapServer);
+        consumerProperties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
+        consumerProperties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProperties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        listTopicsConsumer = new KafkaConsumer<>(consumerProperties);
+
+        log.info("Kafka Query Change Log Source watching " + kafkaBootstrapServer + " started.");
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        log.info("Kafka Query Change Log Source watching " + kafkaBootstrapServer + " shutting down...");
+
+        lock.lock();
+        try {
+            // Shut down the consumer that's used to list topics.
+            listTopicsConsumer.close();
+        } finally {
+            lock.unlock();
+        }
+
+        log.info("Kafka Query Change Log Source watching " + kafkaBootstrapServer + " shut down.");
+    }
+
+    @Override
+    public void subscribe(final SourceListener listener) {
+        requireNonNull(listener);
+        lock.lock();
+        try {
+            // Add the listener to the list of known listeners.
+            listeners.add(listener);
+
+            // Notify it with everything that already exists.
+            for(final Entry<String, String> entry : knownChangeLogs.entrySet()) {
+                final String changeLogTopic = entry.getValue();
+                final KafkaQueryChangeLog changeLog = KafkaQueryChangeLogFactory.make(kafkaBootstrapServer, changeLogTopic);
+                listener.notifyCreate(entry.getKey(), changeLog);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void unsubscribe(final SourceListener listener) {
+        requireNonNull(listener);
+        lock.lock();
+        try {
+            // Remove the listener from the list of known listeners.
+            listeners.remove(listener);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    protected void runOneIteration() throws Exception {
+        lock.lock();
+        try {
+            // Get the list of topics from the Kafka Server.
+            final Set<String> changeLogTopics = new HashSet<>( listTopicsConsumer.listTopics().keySet() );
+
+            // Remove all topics that are not valid Rya Query Change Log topic names.
+            changeLogTopics.removeIf( topic -> !KafkaTopics.getRyaInstance(topic).isPresent() );
+
+            // Extract the Rya instance names from the change log topics.
+            final Set<String> ryaInstances = changeLogTopics.stream()
+                    .map(topic -> KafkaTopics.getRyaInstance(topic).get() )
+                    .collect(Collectors.toSet());
+
+            // Any Rya instances that are in the old set of topics, but not the new one, have been deleted.
+            final Set<String> deletedRyaInstances = new HashSet<>( Sets.difference(knownChangeLogs.keySet(), ryaInstances) );
+
+            // Any Rya instances that are in the new set of topics, but not the old set, have been created.
+            final Set<String> createdRyaInstances = new HashSet<>( Sets.difference(ryaInstances, knownChangeLogs.keySet()) );
+
+            // Handle the deletes.
+            for(final String deletedRyaInstance : deletedRyaInstances) {
+                // Remove the change log from the set of known logs.
+                knownChangeLogs.remove(deletedRyaInstance);
+
+                // Notify the listeners of the update so that they may close the previously provided change log.
+                for(final SourceListener listener : listeners) {
+                    listener.notifyDelete(deletedRyaInstance);
+                }
+            }
+
+            // Handle the adds.
+            for(final String createdRyaInstance : createdRyaInstances) {
+                // Create and store the ChangeLog.
+                final String changeLogTopic = KafkaTopics.queryChangeLogTopic(createdRyaInstance);
+                knownChangeLogs.put(createdRyaInstance, changeLogTopic);
+
+                // Notify the listeners of the update.
+                for(final SourceListener listener : listeners) {
+                    final KafkaQueryChangeLog changeLog = KafkaQueryChangeLogFactory.make(kafkaBootstrapServer, changeLogTopic);
+                    listener.notifyCreate(createdRyaInstance, changeLog);
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+        return scheduler;
+    }
+}

--- a/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/kafka/LocalQueryExecutor.java
+++ b/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/kafka/LocalQueryExecutor.java
@@ -1,0 +1,214 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager.kafka;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.rya.streams.api.entity.StreamsQuery;
+import org.apache.rya.streams.kafka.KafkaStreamsFactory;
+import org.apache.rya.streams.kafka.KafkaStreamsFactory.KafkaStreamsFactoryException;
+import org.apache.rya.streams.kafka.KafkaTopics;
+import org.apache.rya.streams.kafka.interactor.CreateKafkaTopic;
+import org.apache.rya.streams.querymanager.QueryExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractIdleService;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import kafka.consumer.KafkaStream;
+
+/**
+ * A {@link QueryExecutor} that runs a {@link KafkaStreams} job within its own JVM every
+ * time {@link #startQuery(String, StreamsQuery)} is invoked.
+ * <p/>
+ * This executor may run out of JVM resources if it is used to execute too many queries.
+ */
+@DefaultAnnotation(NonNull.class)
+public class LocalQueryExecutor extends AbstractIdleService implements QueryExecutor {
+    private static final Logger log = LoggerFactory.getLogger(LocalQueryExecutor.class);
+
+    /**
+     * Provides thread safety when interacting with this class.
+     */
+    public static ReentrantLock lock = new ReentrantLock();
+
+    /**
+     * Lookup the Rya Instance of a specific Query Id.
+     */
+    private final Map<UUID, String> ryaInstanceById = new HashMap<>();
+
+    /**
+     * Lookup the Query IDs that are running for a specific Rya Instance.
+     */
+    private final Multimap<String, UUID> idByRyaInstance = HashMultimap.create();
+
+    /**
+     * Lookup the executing {@link KafkaStreams} job for a running Query Id.
+     */
+    private final Map<UUID, KafkaStreams> byQueryId = new HashMap<>();
+
+    /**
+     * Used to create the input and output topics for a Kafka Streams job.
+     */
+    private final CreateKafkaTopic createKafkaTopic;
+
+    /**
+     * Builds the {@link KafkaStreams} objects that execute {@link KafkaStream}s.
+     */
+    private final KafkaStreamsFactory streamsFactory;
+
+    /**
+     * Constructs an instance of {@link LocalQueryExecutor}.
+     *
+     * @param createKafkaTopic - Used to create the input and output topics for a Kafka Streams job. (not null)
+     * @param streamsFactory - Builds the {@link KafkaStreams} objects that execute {@link KafkaStream}s. (not null)
+     */
+    public LocalQueryExecutor(
+            final CreateKafkaTopic createKafkaTopic,
+            final KafkaStreamsFactory streamsFactory) {
+        this.createKafkaTopic = requireNonNull(createKafkaTopic);
+        this.streamsFactory = requireNonNull(streamsFactory);
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        log.info("Local Query Executor starting up.");
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        log.info("Local Query Executor shutting down. Stopping all jobs...");
+
+        // Stop all of the running queries.
+        for(final KafkaStreams job : byQueryId.values()) {
+            job.close();
+        }
+
+        log.info("Local Query Executor shut down.");
+    }
+
+    @Override
+    public void startQuery(final String ryaInstance, final StreamsQuery query) throws QueryExecutorException {
+        requireNonNull(ryaInstance);
+        requireNonNull(query);
+        checkState(state() == State.RUNNING, "The service must be RUNNING to execute this method.");
+
+        lock.lock();
+        try {
+            // Make sure the Statements topic exists for the query.
+            final Set<String> topics = Sets.newHashSet(
+                    KafkaTopics.statementsTopic(ryaInstance),
+                    KafkaTopics.queryResultsTopic(query.getQueryId()));
+
+            // Make sure the Query Results topic exists for the query.
+            createKafkaTopic.createTopics(topics, 1, 1);
+
+            // Setup the Kafka Streams job that will execute.
+            final KafkaStreams streams = streamsFactory.make(ryaInstance, query);
+            streams.start();
+
+            // Mark which Rya Instance the Query ID is for.
+            ryaInstanceById.put(query.getQueryId(), ryaInstance);
+
+            // Add the Query ID to the collection of running queries for the Rya instance.
+            idByRyaInstance.put(ryaInstance, query.getQueryId());
+
+            // Add the running Kafka Streams job for the Query ID.
+            byQueryId.put(query.getQueryId(), streams);
+
+        } catch (final KafkaStreamsFactoryException e) {
+            throw new QueryExecutorException("Could not start query " + query.getQueryId(), e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void stopQuery(final UUID queryId) throws QueryExecutorException {
+        requireNonNull(queryId);
+        checkState(state() == State.RUNNING, "The service must be RUNNING to execute this method.");
+
+        lock.lock();
+        try {
+            if(byQueryId.containsKey(queryId)) {
+                // Stop the job from running.
+                final KafkaStreams streams = byQueryId.get(queryId);
+                streams.close();
+
+                // Remove it from the Rya Instance Name lookup.
+                final String ryaInstance = ryaInstanceById.remove(queryId);
+
+                // Remove it from the collection of running queries for the Rya Instance.
+                idByRyaInstance.remove(ryaInstance, queryId);
+
+                // Remove it from the running Kafka Streams job lookup.
+                byQueryId.remove(queryId);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void stopAll(final String ryaInstanceName) throws QueryExecutorException {
+        requireNonNull(ryaInstanceName);
+        checkState(state() == State.RUNNING, "The service must be RUNNING to execute this method.");
+
+        lock.lock();
+        try {
+            if(idByRyaInstance.containsKey(ryaInstanceName)) {
+                // A defensive copy of the queries so that we may remove them from the maps.
+                final Set<UUID> queryIds = new HashSet<>( idByRyaInstance.get(ryaInstanceName) );
+
+                // Stop each of them.
+                for(final UUID queryId : queryIds) {
+                    stopQuery(queryId);
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public Set<UUID> getRunningQueryIds() throws QueryExecutorException {
+        lock.lock();
+        checkState(state() == State.RUNNING, "The service must be RUNNING to execute this method.");
+
+        try {
+            return new HashSet<>( byQueryId.keySet() );
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/xml/QueryManagerConfigUnmarshaller.java
+++ b/extras/rya.streams/query-manager/src/main/java/org/apache/rya/streams/querymanager/xml/QueryManagerConfigUnmarshaller.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager.xml;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.InputStream;
+import java.net.URL;
+
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.xml.sax.SAXException;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Validates and unmarshalls XML into a {@link QueryManagerConfig} object.
+ */
+@DefaultAnnotation(NonNull.class)
+public class QueryManagerConfigUnmarshaller {
+
+    /**
+     * The path within the project's jar file where the XSD resides.
+     */
+    private static final String XSD_PATH = "QueryManagerConfig.xsd";
+
+    /**
+     * Validates and unmarshalls XML into a {@link QueryManagerConfig} object.
+     *
+     * @param xmlStream - Reads the XML that will be unmarshalled. (not null)
+     * @return A {@link QueryManagerConfig} loaded with the XMLs values.
+     * @throws SAXException Could not load the schema the XML will be validated against.
+     * @throws JAXBException Could not unmarshal the XML into a POJO.
+     */
+    public static QueryManagerConfig unmarshall(final InputStream xmlStream) throws JAXBException, SAXException {
+        requireNonNull(xmlStream);
+
+        // Get an input stream to the XSD file that is packaged inside of the jar.
+        final URL schemaURL = ClassLoader.getSystemResource(XSD_PATH);
+        if(schemaURL == null) {
+            throw new RuntimeException("The Class Loader was unable to find the following resource: " + XSD_PATH);
+        }
+
+        // Get the schema for the object.
+        final SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        final Schema schema = sf.newSchema(schemaURL);
+
+        // Configure the unmarhsaller to validate using the schema.
+        final JAXBContext context = JAXBContext.newInstance(QueryManagerConfig.class);
+        final Unmarshaller unmarshaller = context.createUnmarshaller();
+        unmarshaller.setSchema(schema);
+
+        // Perform the unmarshal.
+        return (QueryManagerConfig) unmarshaller.unmarshal(xmlStream);
+    }
+}

--- a/extras/rya.streams/query-manager/src/main/scripts/rpm/postinstall.sh
+++ b/extras/rya.streams/query-manager/src/main/scripts/rpm/postinstall.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+systemctl enable /opt/rya-streams-query-manager-${rpm.version}/bin/systemd/rya-streams-query-manager.service

--- a/extras/rya.streams/query-manager/src/main/scripts/rpm/preremove.sh
+++ b/extras/rya.streams/query-manager/src/main/scripts/rpm/preremove.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+systemctl disable rya-streams-query-manager.service 

--- a/extras/rya.streams/query-manager/src/main/scripts/rya-streams-query-manager.sh
+++ b/extras/rya.streams/query-manager/src/main/scripts/rya-streams-query-manager.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+NAME=rya-streams-query-manager
+DESC="Rya Streams Query Manager Daemon service"
+
+# The path to JSVC
+EXEC="/usr/bin/jsvc"
+
+# Get the parent directory of the dir this script resides within.
+PROJECT_HOME=$(dirname $(cd $(dirname $0) && pwd))
+
+# This classpath must contain the commons-daemon jar as well as the jar we're executing.
+CLASS_PATH="$PROJECT_HOME/lib/commons-daemon-1.1.0.jar:$PROJECT_HOME/lib/${project.artifactId}-${project.version}-shaded.jar"
+
+# The fully qualified name of the class to execute. This class must implement the Daemon interface.
+DAEMON_CLASS=org.apache.rya.streams.querymanager.QueryManagerDaemon
+
+# The PID file that indicates if rya-streams-query-manager is running. 
+PID="/var/run/$NAME.pid"
+
+# System.out writes to this file...
+LOG_OUT="$PROJECT_HOME/logs/$NAME.out"
+
+# System.err writes to this file...
+LOG_ERR="$PROJECT_HOME/logs/$NAME.err"
+
+start ()
+{
+    if [ -f "$PID" ]
+    then
+        echo "The $DESC is already running."
+        exit 1
+    else
+        echo "Starting the $DESC."
+        $EXEC -cp $CLASS_PATH -user root -outfile $LOG_OUT -errfile $LOG_ERR -pidfile $PID \
+              -Dlog4j.configuration="file://$PROJECT_HOME/config/log4j.xml" \
+              $DAEMON_CLASS -c "$PROJECT_HOME/config/configuration.xml"
+    fi
+}
+
+stop ()
+{
+    if [ -f "$PID" ]
+    then
+        echo "Stopping the $DESC."
+        $EXEC -cp $CLASS_PATH -user root -outfile $LOG_OUT -errfile $LOG_ERR -pidfile $PID -stop $DAEMON_CLASS
+    else
+        echo "The $DESC is already stopped."
+    fi
+}
+
+status ()
+{
+    if [ -f "$PID" ]
+    then
+        echo "The $DESC is running." 
+    else
+        echo "The $DESC is stopped."
+    fi
+}
+
+restart ()
+{
+    echo "Restarting the $DESC..."
+    if [ -f "$PID" ]; then        
+        # Stop the service
+        stop
+    fi
+    
+    # Start the service
+    start
+    echo "The $DESC has restarted."
+}
+
+usage ()
+{
+    echo "usage: rya-streams-query-manager.sh (start|stop|status|restart)"
+    exit 1
+}
+
+case "$1" in
+    start) start ;;
+    stop) stop ;;
+    status) status ;;
+    restart) restart ;;
+    *) usage ;;
+esac

--- a/extras/rya.streams/query-manager/src/main/scripts/systemd/rya-streams-query-manager.service
+++ b/extras/rya.streams/query-manager/src/main/scripts/systemd/rya-streams-query-manager.service
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+[Unit]
+Description=Rya Streams Query Manager Service
+After=network.target
+
+[Service]
+Type=forking
+PIDFile=/var/run/rya-streams-query-manager.pid
+ExecStart=/opt/rya-streams-query-manager-${rpm.version}/bin/rya-streams-query-manager.sh start
+ExecStop=/opt/rya-streams-query-manager-${rpm.version}/bin/rya-streams-query-manager.sh stop
+ExecReload=/opt/rya-streams-query-manager-${rpm.version}/bin/rya-streams-query-manager.sh restart
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/extras/rya.streams/query-manager/src/main/xsd/QueryManagerConfig.xsd
+++ b/extras/rya.streams/query-manager/src/main/xsd/QueryManagerConfig.xsd
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <!-- Define the Query Manager's schema. -->
+  <xs:element name="queryManagerConfig">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="queryChangeLogSource">
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="kafka" type="kafka"/>
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="queryExecutor">
+            <xs:complexType>
+              <xs:choice>
+                <xs:element name="localKafkaStreams" type="localKafkaStreams"/>
+              </xs:choice>
+            </xs:complexType>
+        </xs:element>
+        <xs:element name="performanceTunning">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="queryChanngeLogDiscoveryPeriod">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="value" type="xs:positiveInteger"/>
+                    <xs:element name="units" type="timeUnits"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
+  <!-- Defines the time units that may be specified. -->
+  <xs:simpleType name="timeUnits" final="restriction">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="MILLISECONDS"/>
+      <xs:enumeration value="SECONDS"/>
+      <xs:enumeration value="MINUTES"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- Define what kafka connection information looks like. -->  
+  <xs:complexType name="kafka">
+    <xs:sequence>
+      <xs:element name="hostname" type="xs:string"/>
+      <xs:element name="port" type="tcpPort" />
+    </xs:sequence>
+  </xs:complexType>
+  
+  <!-- Define what a local Kafka Streams query executor looks like. -->
+  <xs:complexType name="localKafkaStreams">
+    <xs:sequence>
+      <xs:element name="zookeepers" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <!-- Define the legal range for a TCP port. -->
+  <xs:simpleType name="tcpPort">
+    <xs:restriction base="xs:int">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="65535"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/LogEventWorkGeneratorTest.java
+++ b/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/LogEventWorkGeneratorTest.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.rya.streams.api.queries.QueryChangeLog;
+import org.apache.rya.streams.querymanager.QueryManager.LogEvent;
+import org.apache.rya.streams.querymanager.QueryManager.LogEvent.LogEventType;
+import org.apache.rya.streams.querymanager.QueryManager.LogEventWorkGenerator;
+import org.junit.Test;
+
+/**
+ * Unit tests the methods of {@link LogEventWorkGenerator}.
+ */
+public class LogEventWorkGeneratorTest {
+
+    @Test
+    public void shutdownSignalKillsThread() {
+        // The signal that will kill the notifying thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue generated work is offered to.
+        final BlockingQueue<LogEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The listener that will perform the LogEventWorkGenerator work.
+        final LogEventWorkGenerator generator = new LogEventWorkGenerator(queue, 50, TimeUnit.MILLISECONDS, shutdownSignal);
+
+        // A thread that will attempt to notify the generator with a created change log.
+        final Thread notifyThread = new Thread(() -> {
+            generator.notifyCreate("rya", mock(QueryChangeLog.class));
+        });
+
+        // Fill the queue so that nothing may be offered to it.
+        queue.offer(LogEvent.delete("rya"));
+
+        // Start the thread and show that it is still alive after the offer period.
+        notifyThread.start();
+        assertTrue( ThreadUtil.stillAlive(notifyThread, 200) );
+
+        // Set the shutdown signal to true and join the thread. If we were able to join, then it shut down.
+        shutdownSignal.set(true);
+        assertFalse( ThreadUtil.stillAlive(notifyThread, 1000) );
+    }
+
+    @Test
+    public void notifyCreate() throws Exception {
+        // The signal that will kill the notifying thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue generated work is offered to.
+        final BlockingQueue<LogEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The listener that will perform the LogEventWorkGenerator work.
+        final LogEventWorkGenerator generator = new LogEventWorkGenerator(queue, 50, TimeUnit.MILLISECONDS, shutdownSignal);
+
+        // A thread that will attempt to notify the generator with a created change log.
+        final CountDownLatch notified = new CountDownLatch(1);
+        final Thread notifyThread = new Thread(() -> {
+            generator.notifyCreate("rya", mock(QueryChangeLog.class));
+            notified.countDown();
+        });
+
+        try {
+            // Start the thread that performs the notification.
+            notifyThread.start();
+
+            // Wait for the thread to indicate it has notified and check the queue for the value.
+            notified.await(200, TimeUnit.MILLISECONDS);
+            final LogEvent event = queue.poll(200, TimeUnit.MILLISECONDS);
+            assertEquals(LogEventType.CREATE, event.getEventType());
+            assertEquals("rya", event.getRyaInstanceName());
+        } finally {
+            shutdownSignal.set(true);
+            notifyThread.join();
+        }
+    }
+
+    @Test
+    public void notifyDelete() throws Exception {
+        // The signal that will kill the notifying thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue generated work is offered to.
+        final BlockingQueue<LogEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The listener that will perform the LogEventWorkGenerator work.
+        final LogEventWorkGenerator generator = new LogEventWorkGenerator(queue, 50, TimeUnit.MILLISECONDS, shutdownSignal);
+
+        // A thread that will attempt to notify the generator with a deleted change log.
+        final CountDownLatch notified = new CountDownLatch(1);
+        final Thread notifyThread = new Thread(() -> {
+            generator.notifyDelete("rya");
+            notified.countDown();
+        });
+
+        try {
+            // Start the thread that performs the notification.
+            notifyThread.start();
+
+            // Wait for the thread to indicate it has notified and check the queue for the value.
+            notified.await(200, TimeUnit.MILLISECONDS);
+            final LogEvent event = queue.poll(200, TimeUnit.MILLISECONDS);
+            assertEquals(LogEventType.DELETE, event.getEventType());
+            assertEquals("rya", event.getRyaInstanceName());
+        } finally {
+            shutdownSignal.set(true);
+            notifyThread.join();
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/LogEventWorkerTest.java
+++ b/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/LogEventWorkerTest.java
@@ -1,0 +1,245 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.rya.streams.api.entity.StreamsQuery;
+import org.apache.rya.streams.api.queries.InMemoryQueryChangeLog;
+import org.apache.rya.streams.api.queries.QueryChange;
+import org.apache.rya.streams.api.queries.QueryChangeLog;
+import org.apache.rya.streams.querymanager.QueryManager.LogEvent;
+import org.apache.rya.streams.querymanager.QueryManager.LogEventWorker;
+import org.apache.rya.streams.querymanager.QueryManager.QueryEvent;
+import org.junit.Test;
+
+/**
+ * Unit tests the methods of {@link LogEventWorker}.
+ */
+public class LogEventWorkerTest {
+
+    @Test
+    public void shutdownSignalKillsThread() {
+        // The signal that will kill the working thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The thread that will perform the LogEventWorker task.
+        final Thread logEventWorker = new Thread(new LogEventWorker(new ArrayBlockingQueue<>(1),
+                new ArrayBlockingQueue<>(1), 50, TimeUnit.MILLISECONDS, shutdownSignal));
+        logEventWorker.start();
+
+        // Wait longer than the poll time to see if the thread died. Show that it is still running.
+        assertTrue(ThreadUtil.stillAlive(logEventWorker, 200));
+
+        // Set the shutdown signal to true and join the thread. If we were able to join, then it shut down.
+        shutdownSignal.set(true);
+        assertFalse(ThreadUtil.stillAlive(logEventWorker, 500));
+    }
+
+    @Test
+    public void nofity_logCreated_doesNotExist() throws Exception {
+        // The signal that will kill the working thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue used to feed work.
+        final BlockingQueue<LogEvent> logEventQueue = new ArrayBlockingQueue<>(10);
+
+        // The queue work is written to.
+        final BlockingQueue<QueryEvent> queryEventQueue = new ArrayBlockingQueue<>(10);
+
+        // The Query Change Log that will be watched.
+        final QueryChangeLog changeLog = new InMemoryQueryChangeLog();
+
+        // Write a message that indicates a new query should be active.
+        final UUID firstQueryId = UUID.randomUUID();
+        changeLog.write(QueryChange.create(firstQueryId, "select * where { ?a ?b ?c . }", true));
+
+        // Write a message that adds an active query, but then makes it inactive. Because both of these
+        // events are written to the log before the worker subscribes to the repository for updates, they
+        // must result in a single query stopped event.
+        final UUID secondQueryId = UUID.randomUUID();
+        changeLog.write(QueryChange.create(secondQueryId, "select * where { ?d ?e ?f . }", true));
+        changeLog.write(QueryChange.update(secondQueryId, false));
+
+        // Start the worker that will be tested.
+        final Thread logEventWorker = new Thread(new LogEventWorker(logEventQueue,
+                queryEventQueue, 50, TimeUnit.MILLISECONDS, shutdownSignal));
+        logEventWorker.start();
+
+        try {
+            // Write a unit of work that indicates a log was created.
+            final LogEvent createLogEvent = LogEvent.create("rya", changeLog);
+            logEventQueue.offer(createLogEvent);
+
+            // We must see the following Query Events added to the work queue.
+            // Query 1, executing.
+            // Query 2, stopped.
+            Set<QueryEvent> expectedEvents = new HashSet<>();
+            expectedEvents.add(QueryEvent.executing("rya",
+                    new StreamsQuery(firstQueryId, "select * where { ?a ?b ?c . }", true)));
+            expectedEvents.add(QueryEvent.stopped("rya", secondQueryId));
+
+            Set<QueryEvent> queryEvents = new HashSet<>();
+            queryEvents.add( queryEventQueue.poll(500, TimeUnit.MILLISECONDS) );
+            queryEvents.add( queryEventQueue.poll(500, TimeUnit.MILLISECONDS) );
+
+            assertEquals(expectedEvents, queryEvents);
+
+            // Write an event to the change log that stops the first query.
+            changeLog.write(QueryChange.update(firstQueryId, false));
+
+            // Show it was also reflected in the changes.
+            // Query 1, stopped.
+            expectedEvents = new HashSet<>();
+            expectedEvents.add(QueryEvent.stopped("rya", firstQueryId));
+
+            queryEvents = new HashSet<>();
+            queryEvents.add( queryEventQueue.poll(500, TimeUnit.MILLISECONDS) );
+
+            assertEquals(expectedEvents, queryEvents);
+        } finally {
+            shutdownSignal.set(true);
+            logEventWorker.join();
+        }
+    }
+
+    @Test
+    public void nofity_logCreated_exists() throws Exception {
+        // The signal that will kill the working thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue used to feed work.
+        final BlockingQueue<LogEvent> logEventQueue = new ArrayBlockingQueue<>(10);
+
+        // The queue work is written to.
+        final BlockingQueue<QueryEvent> queryEventQueue = new ArrayBlockingQueue<>(10);
+
+        // The Query Change Log that will be watched.
+        final QueryChangeLog changeLog = new InMemoryQueryChangeLog();
+
+        // Write a message that indicates a new query should be active.
+        final UUID firstQueryId = UUID.randomUUID();
+        changeLog.write(QueryChange.create(firstQueryId, "select * where { ?a ?b ?c . }", true));
+
+        // Start the worker that will be tested.
+        final Thread logEventWorker = new Thread(new LogEventWorker(logEventQueue,
+                queryEventQueue, 50, TimeUnit.MILLISECONDS, shutdownSignal));
+        logEventWorker.start();
+
+        try {
+            // Write a unit of work that indicates a log was created.
+            final LogEvent createLogEvent = LogEvent.create("rya", changeLog);
+            logEventQueue.offer(createLogEvent);
+
+            // Say the same log was created a second time.
+            logEventQueue.offer(createLogEvent);
+
+            // Show that only a single unit of work was added for the log. This indicates the
+            // second message was effectively skipped as it would have add its work added twice otherwise.
+            final Set<QueryEvent> expectedEvents = new HashSet<>();
+            expectedEvents.add(QueryEvent.executing("rya",
+                    new StreamsQuery(firstQueryId, "select * where { ?a ?b ?c . }", true)));
+
+            final Set<QueryEvent> queryEvents = new HashSet<>();
+            queryEvents.add( queryEventQueue.poll(500, TimeUnit.MILLISECONDS) );
+
+            assertNull(queryEventQueue.poll(500, TimeUnit.MILLISECONDS));
+            assertEquals(expectedEvents, queryEvents);
+        } finally {
+            shutdownSignal.set(true);
+            logEventWorker.join();
+        }
+    }
+
+    @Test
+    public void notify_logDeleted_exists() throws Exception {
+        // The signal that will kill the working thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue used to feed work.
+        final BlockingQueue<LogEvent> logEventQueue = new ArrayBlockingQueue<>(10);
+
+        // The queue work is written to.
+        final BlockingQueue<QueryEvent> queryEventQueue = new ArrayBlockingQueue<>(10);
+
+        // The Query Change Log that will be watched.
+        final QueryChangeLog changeLog = new InMemoryQueryChangeLog();
+
+        // Start the worker that will be tested.
+        final Thread logEventWorker = new Thread(new LogEventWorker(logEventQueue,
+                queryEventQueue, 50, TimeUnit.MILLISECONDS, shutdownSignal));
+        logEventWorker.start();
+
+        try {
+            // Write a unit of work that indicates a log was created.
+            final LogEvent createLogEvent = LogEvent.create("rya", changeLog);
+            logEventQueue.offer(createLogEvent);
+
+            // Write a unit of work that indicates a log was deleted.
+            logEventQueue.offer(LogEvent.delete("rya"));
+
+            // Show that a single unit of work was created for deleting everything for "rya".
+            assertEquals(QueryEvent.stopALL("rya"),  queryEventQueue.poll(500, TimeUnit.MILLISECONDS));
+            assertNull(queryEventQueue.poll(500, TimeUnit.MILLISECONDS));
+        } finally {
+            shutdownSignal.set(true);
+            logEventWorker.join();
+        }
+    }
+
+    @Test
+    public void notify_logDeleted_doesNotExist() throws Exception {
+        // The signal that will kill the working thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue used to feed work.
+        final BlockingQueue<LogEvent> logEventQueue = new ArrayBlockingQueue<>(10);
+
+        // The queue work is written to.
+        final BlockingQueue<QueryEvent> queryEventQueue = new ArrayBlockingQueue<>(10);
+
+        // Start the worker that will be tested.
+        final Thread logEventWorker = new Thread(new LogEventWorker(logEventQueue,
+                queryEventQueue, 50, TimeUnit.MILLISECONDS, shutdownSignal));
+        logEventWorker.start();
+
+        try {
+            // Write a unit of work that indicates a log was deleted. Since it was never created,
+            // this will not cause anything to be written to the QueryEvent queue.
+            logEventQueue.offer(LogEvent.delete("rya"));
+
+            // Show that a single unit of work was created for deleting everything for "rya".
+            assertNull(queryEventQueue.poll(500, TimeUnit.MILLISECONDS));
+        } finally {
+            shutdownSignal.set(true);
+            logEventWorker.join();
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/QueryEventWorkGeneratorTest.java
+++ b/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/QueryEventWorkGeneratorTest.java
@@ -1,0 +1,265 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.rya.streams.api.entity.StreamsQuery;
+import org.apache.rya.streams.api.queries.ChangeLogEntry;
+import org.apache.rya.streams.api.queries.QueryChange;
+import org.apache.rya.streams.querymanager.QueryManager.QueryEvent;
+import org.apache.rya.streams.querymanager.QueryManager.QueryEventWorkGenerator;
+import org.junit.Test;
+
+/**
+ * Unit tests the methods of {@link QueryEventWorkGenerator}.
+ */
+public class QueryEventWorkGeneratorTest {
+
+    @Test
+    public void shutdownSignalKillsThread() throws Exception {
+        // The signal that will kill the notifying thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue generated work is offered to.
+        final BlockingQueue<QueryEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The listener that will perform the QueryEventWorkGenerator work.
+        final QueryEventWorkGenerator generator =
+                new QueryEventWorkGenerator("rya", new CountDownLatch(1), queue, 50, TimeUnit.MILLISECONDS, shutdownSignal);
+
+        // A thread that will attempt to notify the generator with a created query.
+        final Thread notifyThread = new Thread(() -> {
+            generator.notify(mock(ChangeLogEntry.class), Optional.empty());
+        });
+
+        // Fill the queue so that nothing may be offered to it.
+        queue.offer(QueryEvent.stopALL("rya"));
+
+        // Start the thread and show that it is still alive after the offer period.
+        notifyThread.start();
+        assertTrue( ThreadUtil.stillAlive(notifyThread, 200) );
+
+        // Set the shutdown signal to true and join the thread. If we were able to join, then it shut down.
+        shutdownSignal.set(true);
+        assertFalse( ThreadUtil.stillAlive(notifyThread, 1000) );
+    }
+
+    @Test
+    public void waitsForSubscriptionWork() throws Exception {
+        // The signal that will kill the notifying thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue generated work is offered to.
+        final BlockingQueue<QueryEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The listener that will perform the QueryEventWorkGenerator work.
+        final CountDownLatch latch = new CountDownLatch(1);
+        final QueryEventWorkGenerator generator =
+                new QueryEventWorkGenerator("rya", latch, queue, 50, TimeUnit.MILLISECONDS, shutdownSignal);
+
+        // A thread that will attempt to notify the generator with a created query.
+        final UUID queryId = UUID.randomUUID();
+        final StreamsQuery query = new StreamsQuery(queryId, "query", true);
+        final Thread notifyThread = new Thread(() -> {
+            final QueryChange change = QueryChange.create(queryId, query.getSparql(), query.isActive());
+            final ChangeLogEntry<QueryChange> entry = new ChangeLogEntry<>(0, change);
+            generator.notify(entry, Optional.of(query));
+        });
+
+        // Start the thread.
+        notifyThread.start();
+
+        try {
+            // Wait longer than the blocking period and show the thread is still alive and nothing has been added
+            // to the work queue.
+            Thread.sleep(150);
+            assertTrue( notifyThread.isAlive() );
+
+            // Count down the latch.
+            latch.countDown();
+
+            // Show work was added to the queue and the notifying thread died.
+            final QueryEvent event = queue.poll(500, TimeUnit.MILLISECONDS);
+            final QueryEvent expected = QueryEvent.executing("rya", new StreamsQuery(queryId, query.getSparql(), query.isActive()));
+            assertEquals(expected, event);
+        } finally {
+            shutdownSignal.set(true);
+            notifyThread.join();
+        }
+    }
+
+    @Test
+    public void notifyCreate() throws Exception {
+        // The signal that will kill the notifying thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue generated work is offered to.
+        final BlockingQueue<QueryEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The listener that will perform the QueryEventWorkGenerator work.
+        final CountDownLatch latch = new CountDownLatch(1);
+        latch.countDown();
+        final QueryEventWorkGenerator generator =
+                new QueryEventWorkGenerator("rya", latch, queue, 50, TimeUnit.MILLISECONDS, shutdownSignal);
+
+        // A thread that will attempt to notify the generator with a created query.
+        final UUID queryId = UUID.randomUUID();
+        final StreamsQuery query = new StreamsQuery(queryId, "query", true);
+        final Thread notifyThread = new Thread(() -> {
+            final QueryChange change = QueryChange.create(queryId, query.getSparql(), query.isActive());
+            final ChangeLogEntry<QueryChange> entry = new ChangeLogEntry<>(0, change);
+            generator.notify(entry, Optional.of(query));
+        });
+
+        // Start the thread.
+        notifyThread.start();
+
+        try {
+            // Show work was added to the queue and the notifying thread died.
+            final QueryEvent event = queue.poll(500, TimeUnit.MILLISECONDS);
+            final QueryEvent expected = QueryEvent.executing("rya", new StreamsQuery(queryId, query.getSparql(), query.isActive()));
+            assertEquals(expected, event);
+        } finally {
+            shutdownSignal.set(true);
+            notifyThread.join();
+        }
+    }
+
+    @Test
+    public void notifyDelete() throws Exception {
+        // The signal that will kill the notifying thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue generated work is offered to.
+        final BlockingQueue<QueryEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The listener that will perform the QueryEventWorkGenerator work.
+        final CountDownLatch latch = new CountDownLatch(1);
+        latch.countDown();
+        final QueryEventWorkGenerator generator =
+                new QueryEventWorkGenerator("rya", latch, queue, 50, TimeUnit.MILLISECONDS, shutdownSignal);
+
+        // A thread that will attempt to notify the generator with a deleted query.
+        final UUID queryId = UUID.randomUUID();
+        final Thread notifyThread = new Thread(() -> {
+            final QueryChange change = QueryChange.delete(queryId);
+            final ChangeLogEntry<QueryChange> entry = new ChangeLogEntry<>(0, change);
+            generator.notify(entry, Optional.empty());
+        });
+
+        // Start the thread.
+        notifyThread.start();
+
+        try {
+            // Show work was added to the queue and the notifying thread died.
+            final QueryEvent event = queue.poll(500, TimeUnit.MILLISECONDS);
+            final QueryEvent expected = QueryEvent.stopped("rya", queryId);
+            assertEquals(expected, event);
+        } finally {
+            shutdownSignal.set(true);
+            notifyThread.join();
+        }
+    }
+
+    @Test
+    public void notifyUpdate_isActive() throws Exception {
+        // The signal that will kill the notifying thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue generated work is offered to.
+        final BlockingQueue<QueryEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The listener that will perform the QueryEventWorkGenerator work.
+        final CountDownLatch latch = new CountDownLatch(1);
+        latch.countDown();
+        final QueryEventWorkGenerator generator =
+                new QueryEventWorkGenerator("rya", latch, queue, 50, TimeUnit.MILLISECONDS, shutdownSignal);
+
+        // A thread that will attempt to notify the generator with an update query change.
+        final UUID queryId = UUID.randomUUID();
+        final StreamsQuery query = new StreamsQuery(queryId, "query", true);
+        final Thread notifyThread = new Thread(() -> {
+            final QueryChange change = QueryChange.update(queryId, true);
+            final ChangeLogEntry<QueryChange> entry = new ChangeLogEntry<>(0, change);
+            generator.notify(entry, Optional.of(query));
+        });
+
+        // Start the thread.
+        notifyThread.start();
+
+        try {
+            // Show work was added to the queue and the notifying thread died.
+            final QueryEvent event = queue.poll(500, TimeUnit.MILLISECONDS);
+            final QueryEvent expected = QueryEvent.executing("rya", new StreamsQuery(queryId, query.getSparql(), query.isActive()));
+            assertEquals(expected, event);
+        } finally {
+            shutdownSignal.set(true);
+            notifyThread.join();
+        }
+    }
+
+    @Test
+    public void notifyUpdate_isNotActive() throws Exception {
+        // The signal that will kill the notifying thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue generated work is offered to.
+        final BlockingQueue<QueryEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The listener that will perform the QueryEventWorkGenerator work.
+        final CountDownLatch latch = new CountDownLatch(1);
+        latch.countDown();
+        final QueryEventWorkGenerator generator =
+                new QueryEventWorkGenerator("rya", latch, queue, 50, TimeUnit.MILLISECONDS, shutdownSignal);
+
+        // A thread that will attempt to notify the generator with an update query change.
+        final UUID queryId = UUID.randomUUID();
+        final StreamsQuery query = new StreamsQuery(queryId, "query", false);
+        final Thread notifyThread = new Thread(() -> {
+            final QueryChange change = QueryChange.update(queryId, false);
+            final ChangeLogEntry<QueryChange> entry = new ChangeLogEntry<>(0, change);
+            generator.notify(entry, Optional.of(query));
+        });
+
+        // Start the thread.
+        notifyThread.start();
+
+        try {
+            // Show work was added to the queue and the notifying thread died.
+            final QueryEvent event = queue.poll(500, TimeUnit.MILLISECONDS);
+            final QueryEvent expected = QueryEvent.stopped("rya", queryId);
+            assertEquals(expected, event);
+        } finally {
+            shutdownSignal.set(true);
+            notifyThread.join();
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/QueryEventWorkerTest.java
+++ b/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/QueryEventWorkerTest.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.rya.streams.api.entity.StreamsQuery;
+import org.apache.rya.streams.querymanager.QueryManager.QueryEvent;
+import org.apache.rya.streams.querymanager.QueryManager.QueryEventWorker;
+import org.junit.Test;
+
+/**
+ * Unit tests the methods of {@link QueryManager.QueryEventWorker}.
+ */
+public class QueryEventWorkerTest {
+
+    @Test
+    public void shutdownSignalKillsThread() {
+        // The signal that will kill the working thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The thread that will perform the QueryEventWorker task.
+        final Thread queryEventWorker = new Thread(new QueryEventWorker(new ArrayBlockingQueue<>(1),
+                mock(QueryExecutor.class), 50, TimeUnit.MILLISECONDS, shutdownSignal));
+        queryEventWorker.start();
+
+        // Wait longer than the poll time to see if the thread died. Show that it is still running.
+        assertTrue(ThreadUtil.stillAlive(queryEventWorker, 200));
+
+        // Set the shutdown signal to true and join the thread. If we were able to join, then it shut down.
+        shutdownSignal.set(true);
+        assertFalse(ThreadUtil.stillAlive(queryEventWorker, 1000));
+    }
+
+    @Test
+    public void executingWork() throws Exception {
+        // The signal that will kill the working thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue used to send the execute work to the thread.
+        final BlockingQueue<QueryEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The message that indicates a query needs to be executed.
+        final String ryaInstance = "rya";
+        final StreamsQuery query = new StreamsQuery(UUID.randomUUID(), "sparql", true);
+        final QueryEvent executingEvent = QueryEvent.executing(ryaInstance, query);
+
+        // Release a latch if the startQuery method on the queryExecutor is invoked with the correct values.
+        final CountDownLatch startQueryInvoked = new CountDownLatch(1);
+        final QueryExecutor queryExecutor = mock(QueryExecutor.class);
+        doAnswer(invocation -> {
+            startQueryInvoked.countDown();
+            return null;
+        }).when(queryExecutor).startQuery(ryaInstance, query);
+
+        // The thread that will perform the QueryEventWorker task.
+        final Thread queryEventWorker = new Thread(new QueryEventWorker(queue,
+                queryExecutor, 50, TimeUnit.MILLISECONDS, shutdownSignal));
+        try {
+            queryEventWorker.start();
+
+            // Provide a message indicating a query needs to be executing.
+            queue.put(executingEvent);
+
+            // Verify the Query Executor was told to start the query.
+            assertTrue( startQueryInvoked.await(150, TimeUnit.MILLISECONDS) );
+        } finally {
+            shutdownSignal.set(true);
+            queryEventWorker.join();
+        }
+    }
+
+    @Test
+    public void stoppedWork() throws Exception {
+        // The signal that will kill the working thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue used to send the execute work to the thread.
+        final BlockingQueue<QueryEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The message that indicates a query needs to be stopped.
+        final UUID queryId = UUID.randomUUID();
+        final QueryEvent stoppedEvent = QueryEvent.stopped("rya", queryId);
+
+        // Release a latch if the stopQuery method on the queryExecutor is invoked with the correct values.
+        final CountDownLatch stopQueryInvoked = new CountDownLatch(1);
+        final QueryExecutor queryExecutor = mock(QueryExecutor.class);
+        doAnswer(invocation -> {
+            stopQueryInvoked.countDown();
+            return null;
+        }).when(queryExecutor).stopQuery(queryId);
+
+        final Thread queryEventWorker = new Thread(new QueryEventWorker(queue,
+                queryExecutor, 50, TimeUnit.MILLISECONDS, shutdownSignal));
+        try {
+            // The thread that will perform the QueryEventWorker task.
+            queryEventWorker.start();
+
+            // Provide a message indicating a query needs to be executing.
+            queue.put(stoppedEvent);
+
+            // Verify the Query Executor was told to stop the query.
+            assertTrue( stopQueryInvoked.await(150, TimeUnit.MILLISECONDS) );
+        } finally {
+            shutdownSignal.set(true);
+            queryEventWorker.join();
+        }
+    }
+
+    @Test
+    public void stopAllWork() throws Exception {
+        // The signal that will kill the working thread.
+        final AtomicBoolean shutdownSignal = new AtomicBoolean(false);
+
+        // The queue used to send the execute work to the thread.
+        final BlockingQueue<QueryEvent> queue = new ArrayBlockingQueue<>(1);
+
+        // The message that indicates all queries for a rya instance need to be stopped.
+        final String ryaInstance = "rya";
+        final QueryEvent stopAllEvent = QueryEvent.stopALL(ryaInstance);
+
+        // Release a latch if the stopQuery method on the queryExecutor is invoked with the correct values.
+        final CountDownLatch testMethodInvoked = new CountDownLatch(1);
+        final QueryExecutor queryExecutor = mock(QueryExecutor.class);
+        doAnswer(invocation -> {
+            testMethodInvoked.countDown();
+            return null;
+        }).when(queryExecutor).stopAll(ryaInstance);
+
+        final Thread queryEventWorker = new Thread(new QueryEventWorker(queue,
+                queryExecutor, 50, TimeUnit.MILLISECONDS, shutdownSignal));
+        try {
+            // The thread that will perform the QueryEventWorker task.
+            queryEventWorker.start();
+
+            // Provide a message indicating a query needs to be executing.
+            queue.put(stopAllEvent);
+
+            // Verify the Query Executor was told to stop all the queries.
+            assertTrue( testMethodInvoked.await(150, TimeUnit.MILLISECONDS) );
+        } finally {
+            shutdownSignal.set(true);
+            queryEventWorker.join();
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/QueryManagerTest.java
+++ b/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/QueryManagerTest.java
@@ -1,0 +1,194 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.rya.streams.api.entity.StreamsQuery;
+import org.apache.rya.streams.api.queries.InMemoryQueryChangeLog;
+import org.apache.rya.streams.api.queries.QueryChange;
+import org.apache.rya.streams.api.queries.QueryChangeLog;
+import org.apache.rya.streams.querymanager.QueryChangeLogSource.SourceListener;
+import org.junit.Test;
+
+/**
+ * Unit tests the methods of {@link QueryManager}.
+ */
+public class QueryManagerTest {
+
+    /**
+     * Tests when the query manager is notified to create a new query, the query
+     * is created and started.
+     */
+    @Test
+    public void testCreateQuery() throws Exception {
+        //The new QueryChangeLog
+        final QueryChangeLog newChangeLog = new InMemoryQueryChangeLog();
+        final String ryaInstance = "ryaTestInstance";
+        final StreamsQuery query = new StreamsQuery(UUID.randomUUID(), "some query", true);
+
+        // when the query executor is told to start the test query on the test
+        // rya instance, count down on the countdown latch
+        final QueryExecutor qe = mock(QueryExecutor.class);
+        when(qe.isRunning()).thenReturn(true);
+
+        final CountDownLatch queryStarted = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            queryStarted.countDown();
+            return null;
+        }).when(qe).startQuery(eq(ryaInstance), eq(query));
+        final QueryChangeLogSource source = mock(QueryChangeLogSource.class);
+
+        //When the QueryChangeLogSource is subscribed to in the QueryManager, mock notify of a new QueryChangeLog
+        doAnswer(invocation -> {
+            //The listener created by the Query Manager
+            final SourceListener listener = (SourceListener) invocation.getArguments()[0];
+            listener.notifyCreate(ryaInstance, newChangeLog);
+            newChangeLog.write(QueryChange.create(query.getQueryId(), query.getSparql(), query.isActive()));
+            return null;
+        }).when(source).subscribe(any(SourceListener.class));
+
+        final QueryManager qm = new QueryManager(qe, source, 50, TimeUnit.MILLISECONDS);
+        try {
+            qm.startAndWait();
+            queryStarted.await(5, TimeUnit.SECONDS);
+            verify(qe).startQuery(ryaInstance, query);
+        } finally {
+            qm.stopAndWait();
+        }
+    }
+
+    /**
+     * Tests when the query manager is notified to delete a new query, the query
+     * is stopped and deleted.
+     */
+    @Test
+    public void testDeleteQuery() throws Exception {
+        //The new QueryChangeLog
+        final QueryChangeLog newChangeLog = new InMemoryQueryChangeLog();
+        final StreamsQuery query = new StreamsQuery(UUID.randomUUID(), "some query", true);
+        final String ryaInstance = "ryaTestInstance";
+
+        // when the query executor is told to start the test query on the test
+        // rya instance, count down on the countdown latch
+        final QueryExecutor qe = mock(QueryExecutor.class);
+        when(qe.isRunning()).thenReturn(true);
+
+        final CountDownLatch queryStarted = new CountDownLatch(1);
+        final CountDownLatch queryDeleted = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            queryDeleted.countDown();
+            return null;
+        }).when(qe).stopQuery(query.getQueryId());
+        final QueryChangeLogSource source = mock(QueryChangeLogSource.class);
+
+        // when the query executor is told to start the test query on the test
+        // rya instance, count down on the countdown latch
+        doAnswer(invocation -> {
+            queryStarted.countDown();
+            return null;
+        }).when(qe).startQuery(eq(ryaInstance), eq(query));
+
+        //When the QueryChangeLogSource is subscribed to in the QueryManager, mock notify of a new QueryChangeLog
+        // add the query, so it can be removed
+        doAnswer(invocation -> {
+            //The listener created by the Query Manager
+            final SourceListener listener = (SourceListener) invocation.getArguments()[0];
+            listener.notifyCreate(ryaInstance, newChangeLog);
+            Thread.sleep(1000);
+            newChangeLog.write(QueryChange.create(query.getQueryId(), query.getSparql(), query.isActive()));
+            queryStarted.await(5, TimeUnit.SECONDS);
+            newChangeLog.write(QueryChange.delete(query.getQueryId()));
+            return null;
+        }).when(source).subscribe(any(SourceListener.class));
+
+        final QueryManager qm = new QueryManager(qe, source, 50, TimeUnit.MILLISECONDS);
+        try {
+            qm.startAndWait();
+            queryDeleted.await(5, TimeUnit.SECONDS);
+            verify(qe).stopQuery(query.getQueryId());
+        } finally {
+            qm.stopAndWait();
+        }
+    }
+
+    /**
+     * Tests when the query manager is notified to update an existing query, the
+     * query is stopped.
+     */
+    @Test
+    public void testUpdateQuery() throws Exception {
+        // The new QueryChangeLog
+        final QueryChangeLog newChangeLog = new InMemoryQueryChangeLog();
+        final StreamsQuery query = new StreamsQuery(UUID.randomUUID(), "some query", true);
+        final String ryaInstance = "ryaTestInstance";
+
+        // when the query executor is told to start the test query on the test
+        // rya instance, count down on the countdown latch
+        final QueryExecutor qe = mock(QueryExecutor.class);
+        when(qe.isRunning()).thenReturn(true);
+
+        final CountDownLatch queryStarted = new CountDownLatch(1);
+        final CountDownLatch queryDeleted = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            queryDeleted.countDown();
+            return null;
+        }).when(qe).stopQuery(query.getQueryId());
+        final QueryChangeLogSource source = mock(QueryChangeLogSource.class);
+
+        // when the query executor is told to start the test query on the test
+        // rya instance, count down on the countdown latch
+        doAnswer(invocation -> {
+            queryStarted.countDown();
+            return null;
+        }).when(qe).startQuery(eq(ryaInstance), eq(query));
+
+        // When the QueryChangeLogSource is subscribed to in the QueryManager,
+        // mock notify of a new QueryChangeLog
+        // add the query, so it can be removed
+        doAnswer(invocation -> {
+            // The listener created by the Query Manager
+            final SourceListener listener = (SourceListener) invocation.getArguments()[0];
+            listener.notifyCreate(ryaInstance, newChangeLog);
+            Thread.sleep(1000);
+            newChangeLog.write(QueryChange.create(query.getQueryId(), query.getSparql(), query.isActive()));
+            queryStarted.await(5, TimeUnit.SECONDS);
+            newChangeLog.write(QueryChange.update(query.getQueryId(), false));
+            return null;
+        }).when(source).subscribe(any(SourceListener.class));
+
+        final QueryManager qm = new QueryManager(qe, source, 50, TimeUnit.MILLISECONDS);
+        try {
+            qm.startAndWait();
+            queryDeleted.await(10, TimeUnit.SECONDS);
+            verify(qe).stopQuery(query.getQueryId());
+        } finally {
+            qm.stopAndWait();
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/ThreadUtil.java
+++ b/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/ThreadUtil.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Utilities that are useful for interacting with {@link Thread}s while testing.
+ */
+public class ThreadUtil {
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private ThreadUtil() { }
+
+    /**
+     * A utility function that returns whether a thread is alive or not after waiting
+     * some specified period of time to join it.
+     *
+     * @param thread - The thread that will be joined. (not null)
+     * @param millis - How long to wait to join the thread.
+     * @return {@code true} if the thread is still alive, otherwise {@code false}.
+     */
+    public static boolean stillAlive(final Thread thread, final long millis) {
+        requireNonNull(thread);
+        try {
+            thread.join(millis);
+        } catch (final InterruptedException e) { }
+        return thread.isAlive();
+    }
+}

--- a/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/kafka/KafkaQueryChangeLogSourceIT.java
+++ b/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/kafka/KafkaQueryChangeLogSourceIT.java
@@ -1,0 +1,277 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager.kafka;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.rya.streams.api.queries.QueryChangeLog;
+import org.apache.rya.streams.kafka.KafkaTopics;
+import org.apache.rya.streams.querymanager.QueryChangeLogSource;
+import org.apache.rya.streams.querymanager.QueryChangeLogSource.SourceListener;
+import org.apache.rya.test.kafka.KafkaTestInstanceRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.google.common.util.concurrent.AbstractScheduledService.Scheduler;
+
+/**
+ * Integration tests the methods of {@link KafkaQueryChangeLogSource}.
+ */
+public class KafkaQueryChangeLogSourceIT {
+
+    @Rule
+    public KafkaTestInstanceRule kafka = new KafkaTestInstanceRule(false);
+
+    @Before
+    public void clearTopics() throws InterruptedException {
+        kafka.deleteAllTopics();
+    }
+
+    @Test
+    public void discoverExistingLogs() throws Exception {
+        // Create a valid Query Change Log topic.
+        final String ryaInstance = UUID.randomUUID().toString();
+        final String topic = KafkaTopics.queryChangeLogTopic(ryaInstance);
+        kafka.createTopic(topic);
+
+        // Create the source.
+        final QueryChangeLogSource source = new KafkaQueryChangeLogSource(
+                kafka.getKafkaHostname(),
+                Integer.parseInt( kafka.getKafkaPort() ),
+                Scheduler.newFixedRateSchedule(0, 1, TimeUnit.SECONDS));
+
+        // Register a listener that counts down a latch if it sees the new topic.
+        final CountDownLatch created = new CountDownLatch(1);
+        source.subscribe(new SourceListener() {
+            @Override
+            public void notifyCreate(final String ryaInstanceName, final QueryChangeLog log) {
+                assertEquals(ryaInstance, ryaInstanceName);
+                created.countDown();
+            }
+
+            @Override
+            public void notifyDelete(final String ryaInstanceName) { }
+        });
+
+        try {
+            // Start the source.
+            source.startAndWait();
+
+            // If the latch isn't counted down, then fail the test.
+            assertTrue( created.await(5, TimeUnit.SECONDS) );
+
+        } finally {
+            source.stopAndWait();
+        }
+    }
+
+    @Test
+    public void discoverNewLogs() throws Exception {
+        // Create the source.
+        final QueryChangeLogSource source = new KafkaQueryChangeLogSource(
+                kafka.getKafkaHostname(),
+                Integer.parseInt( kafka.getKafkaPort() ),
+                Scheduler.newFixedRateSchedule(0, 100, TimeUnit.MILLISECONDS));
+
+        // Register a listener that counts down a latch if it sees the new topic.
+        final String ryaInstance = UUID.randomUUID().toString();
+        final CountDownLatch created = new CountDownLatch(1);
+        source.subscribe(new SourceListener() {
+            @Override
+            public void notifyCreate(final String ryaInstanceName, final QueryChangeLog log) {
+                assertEquals(ryaInstance, ryaInstanceName);
+                created.countDown();
+            }
+
+            @Override
+            public void notifyDelete(final String ryaInstanceName) { }
+        });
+
+        try {
+            // Start the source.
+            source.startAndWait();
+
+            // Wait twice the polling duration to ensure it iterates at least once.
+            Thread.sleep(200);
+
+            // Create a valid Query Change Log topic.
+            final String topic = KafkaTopics.queryChangeLogTopic(ryaInstance);
+            kafka.createTopic(topic);
+
+            // If the latch isn't counted down, then fail the test.
+            assertTrue( created.await(5, TimeUnit.SECONDS) );
+        } finally {
+            source.stopAndWait();
+        }
+    }
+
+    @Test
+    public void discoverLogDeletions() throws Exception {
+        // Create a valid Query Change Log topic.
+        final String ryaInstance = UUID.randomUUID().toString();
+        final String topic = KafkaTopics.queryChangeLogTopic(ryaInstance);
+        kafka.createTopic(topic);
+
+        // Create the source.
+        final QueryChangeLogSource source = new KafkaQueryChangeLogSource(
+                kafka.getKafkaHostname(),
+                Integer.parseInt( kafka.getKafkaPort() ),
+                Scheduler.newFixedRateSchedule(0, 1, TimeUnit.SECONDS));
+
+        // Register a listener that uses latches to indicate when the topic is created and deleted.
+        final CountDownLatch created = new CountDownLatch(1);
+        final CountDownLatch deleted = new CountDownLatch(1);
+        source.subscribe(new SourceListener() {
+            @Override
+            public void notifyCreate(final String ryaInstanceName, final QueryChangeLog log) {
+                assertEquals(ryaInstance, ryaInstanceName);
+                created.countDown();
+            }
+
+            @Override
+            public void notifyDelete(final String ryaInstanceName) {
+                assertEquals(ryaInstance, ryaInstanceName);
+                deleted.countDown();
+            }
+        });
+
+        try {
+            // Start the source
+            source.startAndWait();
+
+            // Wait for it to indicate the topic was created.
+            assertTrue( created.await(5, TimeUnit.SECONDS) );
+
+            // Delete the topic.
+            kafka.deleteTopic(topic);
+
+            // If the latch isn't counted down, then fail the test.
+            assertTrue( deleted.await(5, TimeUnit.SECONDS) );
+
+        } finally {
+            source.stopAndWait();
+        }
+    }
+
+    @Test
+    public void newListenerReceivesAllKnownLogs() throws Exception {
+        // Create a valid Query Change Log topic.
+        final String ryaInstance = UUID.randomUUID().toString();
+        final String topic = KafkaTopics.queryChangeLogTopic(ryaInstance);
+        kafka.createTopic(topic);
+
+        // Create the source.
+        final QueryChangeLogSource source = new KafkaQueryChangeLogSource(
+                kafka.getKafkaHostname(),
+                Integer.parseInt( kafka.getKafkaPort() ),
+                Scheduler.newFixedRateSchedule(0, 1, TimeUnit.SECONDS));
+
+        // Register a listener that counts down a latch if it sees the new topic.
+        final CountDownLatch created = new CountDownLatch(1);
+        source.subscribe(new SourceListener() {
+            @Override
+            public void notifyCreate(final String ryaInstanceName, final QueryChangeLog log) {
+                assertEquals(ryaInstance, ryaInstanceName);
+                created.countDown();
+            }
+
+            @Override
+            public void notifyDelete(final String ryaInstanceName) { }
+        });
+
+        try {
+            // Start the source
+            source.startAndWait();
+
+            // Wait for that first listener to indicate the topic was created. This means that one has been cached.
+            assertTrue( created.await(5, TimeUnit.SECONDS) );
+
+            // Register a second listener that counts down when that same topic is encountered. This means the
+            // newly subscribed listener was notified with the already known change log.
+            final CountDownLatch newListenerCreated = new CountDownLatch(1);
+            source.subscribe(new SourceListener() {
+                @Override
+                public void notifyCreate(final String ryaInstanceName, final QueryChangeLog log) {
+                    assertEquals(ryaInstance, ryaInstanceName);
+                    newListenerCreated.countDown();
+                }
+
+                @Override
+                public void notifyDelete(final String ryaInstanceName) { }
+            });
+            assertTrue( newListenerCreated.await(5, TimeUnit.SECONDS) );
+
+        } finally {
+            source.stopAndWait();
+        }
+    }
+
+    @Test
+    public void unsubscribedDoesNotReceiveNotifications() throws Exception {
+        // Create the source.
+        final QueryChangeLogSource source = new KafkaQueryChangeLogSource(
+                kafka.getKafkaHostname(),
+                Integer.parseInt( kafka.getKafkaPort() ),
+                Scheduler.newFixedRateSchedule(0, 100, TimeUnit.MILLISECONDS));
+
+        try {
+            // Start the source.
+            source.startAndWait();
+
+            // Create a listener that flips a boolean to true when it is notified.
+            final AtomicBoolean notified = new AtomicBoolean(false);
+            final SourceListener listener = new SourceListener() {
+                @Override
+                public void notifyCreate(final String ryaInstanceName, final QueryChangeLog log) {
+                    notified.set(true);
+                }
+
+                @Override
+                public void notifyDelete(final String ryaInstanceName) {
+                    notified.set(true);
+                }
+            };
+
+            // Register and then unregister it.
+            source.subscribe(listener);
+            source.unsubscribe(listener);
+
+            // Create a topic.
+            final String ryaInstance = UUID.randomUUID().toString();
+            final String topic = KafkaTopics.queryChangeLogTopic(ryaInstance);
+            kafka.createTopic(topic);
+
+            //Wait longer than the polling time for the listener to be notified.
+            Thread.sleep(300);
+
+            // Show the boolean was never flipped to true.
+            assertFalse(notified.get());
+        } finally {
+            source.stopAndWait();
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/kafka/LocalQueryExecutorIT.java
+++ b/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/kafka/LocalQueryExecutorIT.java
@@ -1,0 +1,150 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager.kafka;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.rya.api.model.VisibilityBindingSet;
+import org.apache.rya.api.model.VisibilityStatement;
+import org.apache.rya.streams.api.entity.StreamsQuery;
+import org.apache.rya.streams.api.interactor.LoadStatements;
+import org.apache.rya.streams.kafka.KafkaStreamsFactory;
+import org.apache.rya.streams.kafka.KafkaTopics;
+import org.apache.rya.streams.kafka.SingleThreadKafkaStreamsFactory;
+import org.apache.rya.streams.kafka.interactor.CreateKafkaTopic;
+import org.apache.rya.streams.kafka.interactor.KafkaLoadStatements;
+import org.apache.rya.streams.kafka.serialization.VisibilityBindingSetDeserializer;
+import org.apache.rya.streams.kafka.serialization.VisibilityStatementSerializer;
+import org.apache.rya.streams.querymanager.QueryExecutor;
+import org.apache.rya.test.kafka.KafkaTestInstanceRule;
+import org.apache.rya.test.kafka.KafkaTestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.ValueFactoryImpl;
+import org.openrdf.query.impl.MapBindingSet;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Integration tests the methods of {@link LocalQueryExecutor}.
+ */
+public class LocalQueryExecutorIT {
+
+    private final String ryaInstance = UUID.randomUUID().toString();
+
+    private Producer<String, VisibilityStatement> stmtProducer = null;
+    private Consumer<String, VisibilityBindingSet> resultConsumer = null;
+
+    @Rule
+    public KafkaTestInstanceRule kafka = new KafkaTestInstanceRule(false);
+
+    @Before
+    public void setup() {
+        // Make sure the topic that the change log uses exists.
+        final String changeLogTopic = KafkaTopics.queryChangeLogTopic("" + ryaInstance);
+        kafka.createTopic(changeLogTopic);
+
+        // Initialize the Statements Producer and the Results Consumer.
+        stmtProducer = KafkaTestUtil.makeProducer(kafka, StringSerializer.class, VisibilityStatementSerializer.class);
+        resultConsumer = KafkaTestUtil.fromStartConsumer(kafka, StringDeserializer.class, VisibilityBindingSetDeserializer.class);
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        stmtProducer.close();
+        resultConsumer.close();
+    }
+
+    @Test
+    public void runQuery() throws Exception {
+        // Test values.
+        final String ryaInstance = "rya";
+        final StreamsQuery sQuery = new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?person <urn:worksAt> ?business . }", true);
+
+        // Create the statements that will be loaded.
+        final ValueFactory vf = new ValueFactoryImpl();
+        final List<VisibilityStatement> statements = new ArrayList<>();
+        statements.add(new VisibilityStatement(vf.createStatement(
+                vf.createURI("urn:Alice"),
+                vf.createURI("urn:worksAt"),
+                vf.createURI("urn:BurgerJoint")), "a"));
+        statements.add(new VisibilityStatement(vf.createStatement(
+                vf.createURI("urn:Bob"),
+                vf.createURI("urn:worksAt"),
+                vf.createURI("urn:TacoShop")), "a"));
+        statements.add(new VisibilityStatement(vf.createStatement(
+                vf.createURI("urn:Charlie"),
+                vf.createURI("urn:worksAt"),
+                vf.createURI("urn:TacoShop")), "a"));
+
+        // Create the expected results.
+        final List<VisibilityBindingSet> expected = new ArrayList<>();
+        MapBindingSet bs = new MapBindingSet();
+        bs.addBinding("person", vf.createURI("urn:Alice"));
+        bs.addBinding("business", vf.createURI("urn:BurgerJoint"));
+        expected.add(new VisibilityBindingSet(bs, "a"));
+        bs = new MapBindingSet();
+        bs.addBinding("person", vf.createURI("urn:Bob"));
+        bs.addBinding("business", vf.createURI("urn:TacoShop"));
+        expected.add(new VisibilityBindingSet(bs, "a"));
+        bs = new MapBindingSet();
+        bs.addBinding("person", vf.createURI("urn:Charlie"));
+        bs.addBinding("business", vf.createURI("urn:TacoShop"));
+        expected.add(new VisibilityBindingSet(bs, "a"));
+
+        // Start the executor that will be tested.
+        final CreateKafkaTopic createKafkaTopic = new CreateKafkaTopic( kafka.getZookeeperServers() );
+        final String kafkaServers = kafka.getKafkaHostname() + ":" + kafka.getKafkaPort();
+        final KafkaStreamsFactory jobFactory = new SingleThreadKafkaStreamsFactory(kafkaServers);
+        final QueryExecutor executor = new LocalQueryExecutor(createKafkaTopic, jobFactory);
+        executor.startAndWait();
+        try {
+            // Start the query.
+            executor.startQuery(ryaInstance, sQuery);
+
+            // Wait for the program to start.
+            Thread.sleep(5000);
+
+            // Write some statements to the program.
+            final String statementsTopic = KafkaTopics.statementsTopic(ryaInstance);
+            final LoadStatements loadStatements = new KafkaLoadStatements(statementsTopic, stmtProducer);
+            loadStatements.fromCollection(statements);
+
+            // Read the output of the streams program.
+            final String resultsTopic = KafkaTopics.queryResultsTopic(sQuery.getQueryId());
+            resultConsumer.subscribe( Lists.newArrayList(resultsTopic) );
+            final List<VisibilityBindingSet> results = KafkaTestUtil.pollForResults(500, 6, 3, resultConsumer);
+            assertEquals(expected, results);
+
+        } finally {
+            executor.stopAndWait();
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/kafka/LocalQueryExecutorTest.java
+++ b/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/kafka/LocalQueryExecutorTest.java
@@ -1,0 +1,300 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager.kafka;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.rya.streams.api.entity.StreamsQuery;
+import org.apache.rya.streams.kafka.KafkaStreamsFactory;
+import org.apache.rya.streams.kafka.interactor.CreateKafkaTopic;
+import org.apache.rya.streams.querymanager.QueryExecutor;
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+
+/**
+ * Unit tests the methods of {@link LocalQueryExecutor}.
+ */
+public class LocalQueryExecutorTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void startQuery_serviceNotStarted() throws Exception {
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), mock(KafkaStreamsFactory.class));
+        executor.startQuery("rya", new StreamsQuery(UUID.randomUUID(), "query", true));
+    }
+
+    @Test
+    public void startQuery() throws Exception {
+        // Test values.
+        final String ryaInstance = "rya";
+        final StreamsQuery query = new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+
+        // Mock the streams factory so that we can tell if the start function is invoked by the executor.
+        final KafkaStreamsFactory jobFactory = mock(KafkaStreamsFactory.class);
+        final KafkaStreams queryJob = mock(KafkaStreams.class);
+        when(jobFactory.make(eq(ryaInstance), eq(query))).thenReturn(queryJob);
+
+        // Start the executor that will be tested.
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), jobFactory);
+        executor.startAndWait();
+        try {
+            // Tell the executor to start the query.
+            executor.startQuery(ryaInstance, query);
+
+            // Show a job was started for that query's ID.
+            verify(queryJob).start();
+        } finally {
+            executor.stopAndWait();
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void stopQuery_serviceNotStarted() throws Exception {
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), mock(KafkaStreamsFactory.class));
+        executor.stopQuery(UUID.randomUUID());
+    }
+
+    @Test
+    public void stopQuery_queryNotRunning() throws Exception {
+        // Start an executor.
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), mock(KafkaStreamsFactory.class));
+        executor.startAndWait();
+        try {
+            // Try to stop a query that was never stareted.
+            executor.stopQuery(UUID.randomUUID());
+        } finally {
+            executor.stopAndWait();
+        }
+    }
+
+    @Test
+    public void stopQuery() throws Exception {
+        // Test values.
+        final String ryaInstance = "rya";
+        final StreamsQuery query = new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+
+        // Mock the streams factory so that we can tell if the stop function is invoked by the executor.
+        final KafkaStreamsFactory jobFactory = mock(KafkaStreamsFactory.class);
+        final KafkaStreams queryJob = mock(KafkaStreams.class);
+        when(jobFactory.make(eq(ryaInstance), eq(query))).thenReturn(queryJob);
+
+        // Start the executor that will be tested.
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), jobFactory);
+        executor.startAndWait();
+        try {
+            // Tell the executor to start the query.
+            executor.startQuery(ryaInstance, query);
+
+            // Tell the executor to stop the query.
+            executor.stopQuery(query.getQueryId());
+
+            // Show a job was stopped for that query's ID.
+            verify(queryJob).close();
+        } finally {
+            executor.stopAndWait();
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void stopAll_serviceNotStarted() throws Exception {
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), mock(KafkaStreamsFactory.class));
+        executor.stopAll("rya");
+    }
+
+    @Test
+    public void stopAll_noneForThatRyaInstance() throws Exception {
+        // Test values.
+        final String ryaInstance = "rya";
+        final StreamsQuery query1= new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+        final StreamsQuery query2= new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+
+        // Mock the streams factory so that we can tell if the stop function is invoked by the executor.
+        final KafkaStreamsFactory jobFactory = mock(KafkaStreamsFactory.class);
+        final KafkaStreams queryJob1 = mock(KafkaStreams.class);
+        final KafkaStreams queryJob2 = mock(KafkaStreams.class);
+        when(jobFactory.make(eq(ryaInstance), eq(query1))).thenReturn(queryJob1);
+        when(jobFactory.make(eq(ryaInstance), eq(query2))).thenReturn(queryJob2);
+
+        // Start the executor that will be tested.
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), jobFactory);
+        executor.startAndWait();
+        try {
+            // Tell the executor to start the queries.
+            executor.startQuery(ryaInstance, query1);
+            executor.startQuery(ryaInstance, query2);
+
+            // Verify both are running.
+            verify(queryJob1).start();
+            verify(queryJob2).start();
+
+            // Tell the executor to stop queries running under rya2.
+            executor.stopAll("someOtherRyaInstance");
+
+            // Show none of the queries were stopped.
+            verify(queryJob1, never()).close();
+            verify(queryJob2, never()).close();
+
+        } finally {
+            executor.stopAndWait();
+        }
+    }
+
+    @Test
+    public void stopAll() throws Exception {
+        // Test values.
+        final String ryaInstance1 = "rya1";
+        final StreamsQuery query1= new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+        final String ryaInstance2 = "rya2";
+        final StreamsQuery query2= new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+
+        // Mock the streams factory so that we can tell if the stop function is invoked by the executor.
+        final KafkaStreamsFactory jobFactory = mock(KafkaStreamsFactory.class);
+        final KafkaStreams queryJob1 = mock(KafkaStreams.class);
+        when(jobFactory.make(eq(ryaInstance1), eq(query1))).thenReturn(queryJob1);
+        final KafkaStreams queryJob2 = mock(KafkaStreams.class);
+        when(jobFactory.make(eq(ryaInstance2), eq(query2))).thenReturn(queryJob2);
+
+        // Start the executor that will be tested.
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), jobFactory);
+        executor.startAndWait();
+        try {
+            // Tell the executor to start the queries.
+            executor.startQuery(ryaInstance1, query1);
+            executor.startQuery(ryaInstance2, query2);
+
+            // Verify both are running.
+            verify(queryJob1).start();
+            verify(queryJob2).start();
+
+            // Tell the executor to stop queries running under rya2.
+            executor.stopAll(ryaInstance2);
+
+            // Show the first query is still running, but the second isn't.
+            verify(queryJob1, never()).close();
+            verify(queryJob2).close();
+
+        } finally {
+            executor.stopAndWait();
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void getRunningQueryIds_serviceNotStarted() throws Exception {
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), mock(KafkaStreamsFactory.class));
+        executor.getRunningQueryIds();
+    }
+
+    @Test
+    public void getRunningQueryIds_noneStarted() throws Exception {
+        // Start an executor.
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), mock(KafkaStreamsFactory.class));
+        executor.startAndWait();
+        try {
+            // Get the list of running queries.
+            final Set<UUID> runningQueries = executor.getRunningQueryIds();
+
+            // Show no queries are reported as running.
+            assertTrue(runningQueries.isEmpty());
+        } finally {
+            executor.stopAndWait();
+        }
+    }
+
+    @Test
+    public void getRunningQueryIds_noneStopped() throws Exception {
+        // Test values.
+        final String ryaInstance = "rya";
+        final StreamsQuery query1 = new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+        final StreamsQuery query2 = new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+        final StreamsQuery query3 = new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+
+        // Mock the streams factory so that we can figure out what is started.
+        final KafkaStreamsFactory jobFactory = mock(KafkaStreamsFactory.class);
+        when(jobFactory.make(eq(ryaInstance), eq(query1))).thenReturn(mock(KafkaStreams.class));
+        when(jobFactory.make(eq(ryaInstance), eq(query2))).thenReturn(mock(KafkaStreams.class));
+        when(jobFactory.make(eq(ryaInstance), eq(query3))).thenReturn(mock(KafkaStreams.class));
+
+        // Start the executor that will be tested.
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), jobFactory);
+        executor.startAndWait();
+        try {
+            // Start the queries.
+            executor.startQuery(ryaInstance, query1);
+            executor.startQuery(ryaInstance, query2);
+            executor.startQuery(ryaInstance, query3);
+
+            // All of those query IDs should be reported as running.
+            final Set<UUID> expected = Sets.newHashSet(
+                    query1.getQueryId(),
+                    query2.getQueryId(),
+                    query3.getQueryId());
+            assertEquals(expected, executor.getRunningQueryIds());
+
+        } finally {
+            executor.stopAndWait();
+        }
+    }
+
+    @Test
+    public void getRunningQueryIds_stoppedNoLongerListed() throws Exception {
+        // Test values.
+        final String ryaInstance = "rya";
+        final StreamsQuery query1 = new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+        final StreamsQuery query2 = new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+        final StreamsQuery query3 = new StreamsQuery(UUID.randomUUID(), "SELECT * WHERE { ?a ?b ?c. }", true);
+
+        // Mock the streams factory so that we can figure out what is started.
+        final KafkaStreamsFactory jobFactory = mock(KafkaStreamsFactory.class);
+        when(jobFactory.make(eq(ryaInstance), eq(query1))).thenReturn(mock(KafkaStreams.class));
+        when(jobFactory.make(eq(ryaInstance), eq(query2))).thenReturn(mock(KafkaStreams.class));
+        when(jobFactory.make(eq(ryaInstance), eq(query3))).thenReturn(mock(KafkaStreams.class));
+
+        // Start the executor that will be tested.
+        final QueryExecutor executor = new LocalQueryExecutor(mock(CreateKafkaTopic.class), jobFactory);
+        executor.startAndWait();
+        try {
+            // Start the queries.
+            executor.startQuery(ryaInstance, query1);
+            executor.startQuery(ryaInstance, query2);
+            executor.startQuery(ryaInstance, query3);
+
+            // Stop the second query.
+            executor.stopQuery(query2.getQueryId());
+
+            // Only the first and third queries are running.
+            final Set<UUID> expected = Sets.newHashSet(
+                    query1.getQueryId(),
+                    query3.getQueryId());
+            assertEquals(expected, executor.getRunningQueryIds());
+
+        } finally {
+            executor.stopAndWait();
+        }
+    }
+}

--- a/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/xml/QueryManagerConfigMarshallerTest.java
+++ b/extras/rya.streams/query-manager/src/test/java/org/apache/rya/streams/querymanager/xml/QueryManagerConfigMarshallerTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rya.streams.querymanager.xml;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import javax.xml.bind.UnmarshalException;
+
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+
+/**
+ * Unit tests the methods of {@link QueryManagerConfigUnmarshaller}.
+ */
+public class QueryManagerConfigMarshallerTest {
+
+    @Test
+    public void unmarshal_validXml() throws Exception {
+        final String xml =
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<queryManagerConfig>\n" +
+                "    <queryChangeLogSource>\n" +
+                "        <kafka>\n" +
+                "            <hostname>localhost</hostname>\n" +
+                "            <port>6</port>\n" +
+                "        </kafka>\n" +
+                "    </queryChangeLogSource>\n" +
+                "    <queryExecutor>\n" +
+                "        <localKafkaStreams>\n" +
+                "            <zookeepers>zoo1,zoo2,zoo3</zookeepers>\n" +
+                "        </localKafkaStreams>\n" +
+                "    </queryExecutor>\n" +
+                "    <performanceTunning>\n" +
+                "        <queryChanngeLogDiscoveryPeriod>\n" +
+                "            <value>1</value>\n" +
+                "            <units>MINUTES</units>\n" +
+                "        </queryChanngeLogDiscoveryPeriod>\n" +
+                "    </performanceTunning>\n" +
+                "</queryManagerConfig>";
+
+        final InputStream xmlStream = new ByteArrayInputStream(xml.getBytes(Charsets.UTF_8));
+        final QueryManagerConfig config = QueryManagerConfigUnmarshaller.unmarshall(xmlStream);
+        assertNotNull(config);
+    }
+
+    @Test(expected = UnmarshalException.class)
+    public void unmarshal_invalidXml() throws Exception {
+        final String xml =
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<queryManagerConfig>\n" +
+                "    <queryChangeLogSource>\n" +
+                "        <kafka>\n" +
+                "            <hostname>localhost</hostname>\n" +
+                "            <port>6</port>\n" +
+                "        </kafka>\n" +
+                "    </queryChangeLogSource>\n" +
+                "</queryManagerConfig>";
+
+        final InputStream xmlStream = new ByteArrayInputStream(xml.getBytes(Charsets.UTF_8));
+        QueryManagerConfigUnmarshaller.unmarshall(xmlStream);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,11 @@ under the License.
             </dependency>
             <dependency>
                 <groupId>org.apache.rya</groupId>
+                <artifactId>rya.streams.client</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.rya</groupId>
                 <artifactId>rya.streams.kafka</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/test/kafka/src/main/java/org/apache/rya/test/kafka/EmbeddedKafkaInstance.java
+++ b/test/kafka/src/main/java/org/apache/rya/test/kafka/EmbeddedKafkaInstance.java
@@ -75,6 +75,7 @@ public class EmbeddedKafkaInstance {
         brokerProps.setProperty(KafkaConfig$.MODULE$.PortProp(), brokerPort);
         brokerProps.setProperty(KafkaConfig$.MODULE$.ZkConnectProp(), zookeperConnect);
         brokerProps.setProperty(KafkaConfig$.MODULE$.LogDirsProp(), Files.createTempDirectory(getClass().getSimpleName() + "-").toAbsolutePath().toString());
+        brokerProps.setProperty(KafkaConfig$.MODULE$.DeleteTopicEnableProp(), "true");
         final KafkaConfig config = new KafkaConfig(brokerProps);
         final Time mock = new MockTime();
         kafkaServer = TestUtils.createServer(config, mock);


### PR DESCRIPTION
### Description
Implemented an RPM installed CentOS 7 daemon service used to execute Kafka Streams jobs on the local machine. This is part of Rya Streams.

Changed query-manager's RPM plugin to use a Java based RPM plugin (de.dentrassi.maven) so other Linux distros/OS’s without rpmbuild could create the RPM.  

### Tests
Wrote automated tests and executed the application on a CentOS 7 machine using the RPM.
Build

### Links
[Jira](https://issues.apache.org/jira/browse/RYA-443)

### Checklist
- [ ] Code Review
- [ ] Squash Commits

#### People To Review
@kchilton2
@isper3at